### PR TITLE
Loosened checks on encoding account claims with limits

### DIFF
--- a/account_claims.go
+++ b/account_claims.go
@@ -75,20 +75,6 @@ func (a *AccountClaims) Encode(pair nkeys.KeyPair) (string, error) {
 		return "", errors.New("expected subject to be account public key")
 	}
 
-	pubKey, err := pair.PublicKey()
-	if err != nil {
-		return "", err
-	}
-
-	if nkeys.IsValidPublicAccountKey(pubKey) {
-		if len(a.Identities) > 0 {
-			return "", errors.New("self-signed account JWTs can't contain identity proofs")
-		}
-		if !a.Limits.IsEmpty() {
-			return "", errors.New("self-signed account JWTs can't contain operator limits")
-		}
-	}
-
 	a.ClaimsData.Type = AccountClaim
 	return a.ClaimsData.encode(pair, a)
 }
@@ -118,10 +104,10 @@ func (a *AccountClaims) Validate(vr *ValidationResults) {
 
 	if nkeys.IsValidPublicAccountKey(a.ClaimsData.Issuer) {
 		if len(a.Identities) > 0 {
-			vr.AddError("self-signed account JWTs can't contain identity proofs")
+			vr.AddWarning("self-signed account JWTs shouldn't contain identity proofs")
 		}
 		if !a.Limits.IsEmpty() {
-			vr.AddError("self-signed account JWTs can't contain operator limits")
+			vr.AddWarning("self-signed account JWTs shouldn't contain operator limits")
 		}
 	}
 }

--- a/account_claims_test.go
+++ b/account_claims_test.go
@@ -47,7 +47,7 @@ func TestNewAccountClaims(t *testing.T) {
 	AssertEquals(account2.Payload() != nil, true, t)
 }
 
-func TestAccountCantSignOperatorLimits(t *testing.T) {
+func TestAccountCanSignOperatorLimits(t *testing.T) { // don't block encoding!!!
 	akp := createAccountNKey(t)
 	apk := publicKey(akp, t)
 
@@ -56,12 +56,12 @@ func TestAccountCantSignOperatorLimits(t *testing.T) {
 	account.Limits.Conn = 1
 
 	_, err := account.Encode(akp)
-	if err == nil {
+	if err != nil {
 		t.Fatal("account should not be able to encode operator limits", err)
 	}
 }
 
-func TestAccountCantSignIdentities(t *testing.T) {
+func TestAccountCanSignIdentities(t *testing.T) { // don't block encoding!!!
 	akp := createAccountNKey(t)
 	apk := publicKey(akp, t)
 
@@ -75,7 +75,7 @@ func TestAccountCantSignIdentities(t *testing.T) {
 	}
 
 	_, err := account.Encode(akp)
-	if err == nil {
+	if err != nil {
 		t.Fatal("account should not be able to encode identities", err)
 	}
 }
@@ -257,8 +257,8 @@ func TestLimitValidationInAccount(t *testing.T) {
 	vr = CreateValidationResults()
 	account.Validate(vr)
 
-	if len(vr.Issues) != 1 || !vr.IsBlocking(true) {
-		t.Fatal("bad issuer should be blocking")
+	if vr.IsEmpty() || vr.IsBlocking(true) {
+		t.Fatal("bad issuer for limits should have non-blocking validation results")
 	}
 
 	account.Identities = []Identity{
@@ -272,8 +272,8 @@ func TestLimitValidationInAccount(t *testing.T) {
 	vr = CreateValidationResults()
 	account.Validate(vr)
 
-	if len(vr.Issues) != 1 || !vr.IsBlocking(true) {
-		t.Fatal("bad issuer should be blocking")
+	if vr.IsEmpty() || vr.IsBlocking(true) {
+		t.Fatal("bad issuer for identities should have non-blocking validation results")
 	}
 
 	account.Identities = nil


### PR DESCRIPTION
Removed check on limits/identity from encode for accounts
Made self signed limits a warning (so ngs+nsc can edit them)
Fixed tests