### PR TITLE
LeafNode OperatorLimits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
 language: go
 sudo: false
 go:
-- 1.9.x
-- 1.10.x
+- 1.12.x
 - 1.11.x
 
 install:
 - go get -t ./...
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
+- go get -u honnef.co/go/tools/cmd/staticcheck
+- go get -u github.com/client9/misspell/cmd/misspell
 
 before_script:
 - $(exit $(go fmt ./... | wc -l))
 - go vet ./...
+- misspell -error -locale US .
+- staticcheck ./...
 
 script:
 - if [[ "$TRAVIS_GO_VERSION" == 1.10.* ]] ; then ./scripts/cov.sh TRAVIS; else go test -v -race ./...; fi

--- a/account_claims.go
+++ b/account_claims.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The NATS Authors
+ * Copyright 2018-2019 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -28,6 +28,7 @@ const NoLimit = -1
 type OperatorLimits struct {
 	Subs            int64 `json:"subs,omitempty"`      // Max number of subscriptions
 	Conn            int64 `json:"conn,omitempty"`      // Max number of active connections
+	LeafNodeConn    int64 `json:"leaf,omitempty"`      // Max number of active leaf node connections
 	Imports         int64 `json:"imports,omitempty"`   // Max number of imports
 	Exports         int64 `json:"exports,omitempty"`   // Max number of exports
 	Data            int64 `json:"data,omitempty"`      // Max number of bytes
@@ -42,7 +43,7 @@ func (o *OperatorLimits) IsEmpty() bool {
 
 // IsUnlimited returns true if all limits are
 func (o *OperatorLimits) IsUnlimited() bool {
-	return *o == OperatorLimits{NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, true}
+	return *o == OperatorLimits{NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, true}
 }
 
 // Validate checks that the operator limits contain valid values
@@ -107,7 +108,7 @@ func NewAccountClaims(subject string) *AccountClaims {
 	c := &AccountClaims{}
 	// Set to unlimited to start. We do it this way so we get compiler
 	// errors if we add to the OperatorLimits.
-	c.Limits = OperatorLimits{NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, true}
+	c.Limits = OperatorLimits{NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, true}
 	c.Subject = subject
 	return c
 }

--- a/account_claims_test.go
+++ b/account_claims_test.go
@@ -73,7 +73,8 @@ func TestAccountCanSignOperatorLimits(t *testing.T) { // don't block encoding!!!
 
 	account := NewAccountClaims(apk)
 	account.Expires = time.Now().Add(time.Duration(time.Hour * 24 * 365)).Unix()
-	account.Limits.Conn = 1
+	account.Limits.Conn = 10
+	account.Limits.LeafNodeConn = 2
 
 	_, err := account.Encode(akp)
 	if err != nil {
@@ -108,6 +109,8 @@ func TestOperatorCanSignClaims(t *testing.T) {
 	account := NewAccountClaims(apk)
 	account.Expires = time.Now().Add(time.Duration(time.Hour * 24 * 365)).Unix()
 	account.Limits.Conn = 1
+	account.Limits.LeafNodeConn = 4
+
 	account.Identities = []Identity{
 		{
 			ID:    "stephen",
@@ -124,6 +127,13 @@ func TestOperatorCanSignClaims(t *testing.T) {
 
 	AssertEquals(account.String(), account2.String(), t)
 	AssertEquals(account2.IsSelfSigned(), false, t)
+
+	if account2.Limits.Conn != 1 {
+		t.Fatalf("Expected Limits.Conn == 1, got %d", account2.Limits.Conn)
+	}
+	if account2.Limits.LeafNodeConn != 4 {
+		t.Fatalf("Expected Limits.Conn == 4, got %d", account2.Limits.LeafNodeConn)
+	}
 }
 
 func TestInvalidAccountClaimIssuer(t *testing.T) {


### PR DESCRIPTION
Added in leaf node connection limits.

Updates Go versions and added in staticcheck and misspell tests.