### PR TITLE
FIX #28, Fix #29

### DIFF
--- a/account_claims_test.go
+++ b/account_claims_test.go
@@ -44,7 +44,7 @@ func TestNewAccountClaims(t *testing.T) {
 	account.Expires = time.Now().Add(time.Duration(time.Hour * 24 * 365)).UTC().Unix()
 
 	account.Imports = Imports{}
-	account.Imports.Add(&Import{Subject: "test", Name: "test import", Account: apk2, Token: actJWT, To: "my", Type: Stream})
+	account.Imports.Add(&Import{RemoteSubject: "test", Name: "test import", Account: apk2, Token: actJWT, LocalSubject: "my", Type: Stream})
 
 	vr := CreateValidationResults()
 	account.Validate(vr)
@@ -194,9 +194,6 @@ func TestInvalidAccountSubjects(t *testing.T) {
 		var err error
 
 		c := NewAccountClaims(pk)
-		if i.ok && err != nil {
-			t.Fatalf("error encoding activation: %v", err)
-		}
 		_, err = c.Encode(i.kp)
 		if i.ok && err != nil {
 			t.Fatal(fmt.Sprintf("unexpected error for %q: %v", i.name, err))

--- a/activation_claims.go
+++ b/activation_claims.go
@@ -117,6 +117,11 @@ func (a *ActivationClaims) String() string {
 	return a.ClaimsData.String(a)
 }
 
+// Migrated returns true if the activation claim was migrated during a read
+func (a *ActivationClaims) Migrated() bool {
+	return false
+}
+
 // HashID returns a hash of the claims that can be used to identify it.
 // The hash is calculated by creating a string with
 // issuerPubKey.subjectPubKey.<subject> and constructing the sha-256 hash and base32 encoding that.

--- a/claims.go
+++ b/claims.go
@@ -53,6 +53,7 @@ type Claims interface {
 	Claims() *ClaimsData
 	Encode(kp nkeys.KeyPair) (string, error)
 	ExpectedPrefixes() []nkeys.PrefixByte
+	Migrated() bool
 	Payload() interface{}
 	String() string
 	Validate(vr *ValidationResults)

--- a/cluster_claims.go
+++ b/cluster_claims.go
@@ -92,3 +92,8 @@ func (c *ClusterClaims) ExpectedPrefixes() []nkeys.PrefixByte {
 func (c *ClusterClaims) Claims() *ClaimsData {
 	return &c.ClaimsData
 }
+
+// Migrated returns true if the cluster claim was migrated during a read
+func (c *ClusterClaims) Migrated() bool {
+	return false
+}

--- a/exports.go
+++ b/exports.go
@@ -81,7 +81,7 @@ func isContainedIn(kind ExportType, subjects []Subject, vr *ValidationResults) {
 }
 
 // Validate calls validate on all of the exports
-func (e *Exports) Validate(vr *ValidationResults) error {
+func (e *Exports) Validate(vr *ValidationResults) {
 	var serviceSubjects []Subject
 	var streamSubjects []Subject
 
@@ -96,8 +96,6 @@ func (e *Exports) Validate(vr *ValidationResults) error {
 
 	isContainedIn(Service, serviceSubjects, vr)
 	isContainedIn(Stream, streamSubjects, vr)
-
-	return nil
 }
 
 // HasExportContainingSubject checks if the export list has an export with the provided subject

--- a/genericlaims.go
+++ b/genericlaims.go
@@ -63,6 +63,12 @@ func (gc *GenericClaims) Validate(vr *ValidationResults) {
 	gc.ClaimsData.Validate(vr)
 }
 
+// Migrated returns true if the cluster claim was migrated during a read
+// GenericClaims will always return false
+func (gc *GenericClaims) Migrated() bool {
+	return false
+}
+
 func (gc *GenericClaims) String() string {
 	return gc.ClaimsData.String(gc)
 }

--- a/imports.go
+++ b/imports.go
@@ -24,12 +24,17 @@ import (
 
 // Import describes a mapping from another account into this one
 type Import struct {
-	Name    string     `json:"name,omitempty"`
-	Subject Subject    `json:"subject,omitempty"`
-	Account string     `json:"account,omitempty"`
-	Token   string     `json:"token,omitempty"`
-	To      Subject    `json:"to,omitempty"`
-	Type    ExportType `json:"type,omitempty"`
+	Account       string     `json:"account,omitempty"`
+	LocalSubject  Subject    `json:"local_subject,omitempty"`
+	Name          string     `json:"name,omitempty"`
+	RemoteSubject Subject    `json:"remote_subject,omitempty"`
+	Token         string     `json:"token,omitempty"`
+	Type          ExportType `json:"type,omitempty"`
+	// Deprecated: use Local/Remote
+	Subject Subject `json:"subject,omitempty"`
+	// Deprecated: use Local/Remote
+	To       Subject `json:"to,omitempty"`
+	migrated bool
 }
 
 // IsService returns true if the import is of type service
@@ -52,34 +57,28 @@ func (i *Import) Validate(actPubKey string, vr *ValidationResults) {
 		vr.AddWarning("account to import from is not specified")
 	}
 
-	i.Subject.Validate(vr)
-
-	if i.IsService() {
-		if i.Subject.HasWildCards() {
-			vr.AddWarning("services cannot have wildcard subject: %q", i.Subject)
-		}
-	}
+	i.RemoteSubject.Validate(vr)
 
 	var act *ActivationClaims
 
 	if i.Token != "" {
 		// Check to see if its an embedded JWT or a URL.
-		if url, err := url.Parse(i.Token); err == nil && url.Scheme != "" {
+		if u, err := url.Parse(i.Token); err == nil && u.Scheme != "" {
 			c := &http.Client{Timeout: 5 * time.Second}
-			resp, err := c.Get(url.String())
+			resp, err := c.Get(u.String())
 			if err != nil {
-				vr.AddWarning("import %s contains an unreachable token URL %q", i.Subject, i.Token)
+				vr.AddWarning("import %s contains an unreachable token URL %q", i.RemoteSubject, i.Token)
 			}
 
 			if resp != nil {
 				defer resp.Body.Close()
 				body, err := ioutil.ReadAll(resp.Body)
 				if err != nil {
-					vr.AddWarning("import %s contains an unreadable token URL %q", i.Subject, i.Token)
+					vr.AddWarning("import %s contains an unreadable token URL %q", i.RemoteSubject, i.Token)
 				} else {
 					act, err = DecodeActivationClaims(string(body))
 					if err != nil {
-						vr.AddWarning("import %s contains a url %q with an invalid activation token", i.Subject, i.Token)
+						vr.AddWarning("import %s contains a url %q with an invalid activation token", i.RemoteSubject, i.Token)
 					}
 				}
 			}
@@ -87,21 +86,21 @@ func (i *Import) Validate(actPubKey string, vr *ValidationResults) {
 			var err error
 			act, err = DecodeActivationClaims(i.Token)
 			if err != nil {
-				vr.AddWarning("import %q contains an invalid activation token", i.Subject)
+				vr.AddWarning("import %q contains an invalid activation token", i.RemoteSubject)
 			}
 		}
 	}
 
 	if act != nil {
 		if act.Issuer != i.Account {
-			vr.AddWarning("activation token doesn't match account for import %q", i.Subject)
+			vr.AddWarning("activation token doesn't match account for import %q", i.RemoteSubject)
 		}
 
 		if act.ClaimsData.Subject != actPubKey {
-			vr.AddWarning("activation token doesn't match account it is being included in, %q", i.Subject)
+			vr.AddWarning("activation token doesn't match account it is being included in, %q", i.RemoteSubject)
 		}
 	} else {
-		vr.AddWarning("no activation provided for import %s", i.Subject)
+		vr.AddWarning("no activation provided for import %s", i.RemoteSubject)
 	}
 
 }

--- a/operator_claims.go
+++ b/operator_claims.go
@@ -135,3 +135,8 @@ func (s *OperatorClaims) ExpectedPrefixes() []nkeys.PrefixByte {
 func (s *OperatorClaims) Claims() *ClaimsData {
 	return &s.ClaimsData
 }
+
+// Migrated returns true if the cluster claim was migrated during a read
+func (s *OperatorClaims) Migrated() bool {
+	return false
+}

--- a/revocation_claims.go
+++ b/revocation_claims.go
@@ -103,3 +103,8 @@ func (rc *RevocationClaims) ExpectedPrefixes() []nkeys.PrefixByte {
 func (rc *RevocationClaims) Claims() *ClaimsData {
 	return &rc.ClaimsData
 }
+
+// Migrated returns true if the revocation claim was migrated during a read
+func (rc *RevocationClaims) Migrated() bool {
+	return false
+}

--- a/server_claims.go
+++ b/server_claims.go
@@ -92,3 +92,8 @@ func (s *ServerClaims) ExpectedPrefixes() []nkeys.PrefixByte {
 func (s *ServerClaims) Claims() *ClaimsData {
 	return &s.ClaimsData
 }
+
+// Migrated returns true if the server claim was migrated during a read
+func (s *ServerClaims) Migrated() bool {
+	return false
+}

--- a/user_claims.go
+++ b/user_claims.go
@@ -88,6 +88,11 @@ func (u *UserClaims) Payload() interface{} {
 	return &u.User
 }
 
+// Migrated returns true if the user claim was migrated during a read
+func (u *UserClaims) Migrated() bool {
+	return false
+}
+
 func (u *UserClaims) String() string {
 	return u.ClaimsData.String(u)
 }


### PR DESCRIPTION
Fix #28
- Deprecated Import#Subject and Import#To, replaced by Import#RemoteSubject and Import#LocalSubject respectively.
- On read, Import#Subject is mapped to Import#RemoteSubject and Import#Subject is cleared
- On read, Import#To is mapped to Import#LocalSubject and Import#To is cleared
- Added Migrated() to claim interface to allow toolchains to understand if a JWT was migrated, all code must be updated to refer only to RemoteSubject and LocalSubject.

Fix #30 - Removed restriction where services cannot have wildcards. Of course, they can.

Fixed linter warnings about errors and `url` package collisions.