### PR TITLE
Add IssuerAccount to User/Activation Claims

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ test:
 	go vet ./...
 	go test -v
 	go test -v --race
+	staticcheck ./...
 
 fmt:
 	gofmt -w -s *.go

--- a/activation_claims.go
+++ b/activation_claims.go
@@ -62,6 +62,9 @@ func (a *Activation) Validate(vr *ValidationResults) {
 type ActivationClaims struct {
 	ClaimsData
 	Activation `json:"nats,omitempty"`
+	// IssuerAccount stores the public key for the account the issuer represents.
+	// When set, the claim was issued by a signing key.
+	IssuerAccount string `json:"issuer_account,omitempty"`
 }
 
 // NewActivationClaims creates a new activation claim with the provided sub
@@ -101,6 +104,9 @@ func (a *ActivationClaims) Payload() interface{} {
 func (a *ActivationClaims) Validate(vr *ValidationResults) {
 	a.ClaimsData.Validate(vr)
 	a.Activation.Validate(vr)
+	if a.IssuerAccount != "" && !nkeys.IsValidPublicAccountKey(a.IssuerAccount) {
+		vr.AddError("account_id is not an account public key")
+	}
 }
 
 // ExpectedPrefixes defines the types that can sign an activation jwt, account and oeprator

--- a/user_claims.go
+++ b/user_claims.go
@@ -37,6 +37,9 @@ func (u *User) Validate(vr *ValidationResults) {
 type UserClaims struct {
 	ClaimsData
 	User `json:"nats,omitempty"`
+	// IssuerAccount stores the public key for the account the issuer represents.
+	// When set, the claim was issued by a signing key.
+	IssuerAccount string `json:"issuer_account,omitempty"`
 }
 
 // NewUserClaims creates a user JWT with the specific subject/public key
@@ -71,6 +74,9 @@ func DecodeUserClaims(token string) (*UserClaims, error) {
 func (u *UserClaims) Validate(vr *ValidationResults) {
 	u.ClaimsData.Validate(vr)
 	u.User.Validate(vr)
+	if u.IssuerAccount != "" && !nkeys.IsValidPublicAccountKey(u.IssuerAccount) {
+		vr.AddError("account_id is not an account public key")
+	}
 }
 
 // ExpectedPrefixes defines the types that can encode a user JWT, account

--- a/user_claims_test.go
+++ b/user_claims_test.go
@@ -284,7 +284,6 @@ func TestUserAccountID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-
 	uc, err = DecodeUserClaims(userToken)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
When a user or activation token is issued with a signing key there's no way to locate the account of record to verify the signing key. Added an `IssuerAccount` that when set, directs tooling to resolve the account JWT specified so that the signing key can be verified.