### PR TITLE
Changed user/activation limit validation to CIDR

### DIFF
--- a/activation_claims_test.go
+++ b/activation_claims_test.go
@@ -33,7 +33,7 @@ func TestNewActivationClaims(t *testing.T) {
 	activation.Expires = time.Now().Add(time.Duration(time.Hour)).Unix()
 	activation.Limits.Max = 10
 	activation.Limits.Payload = 10
-	activation.Limits.Src = "255.255.255.0"
+	activation.Limits.Src = "192.0.2.0/24"
 
 	activation.ImportSubject = "foo"
 	activation.Name = "Foo"
@@ -223,7 +223,7 @@ func TestActivationValidation(t *testing.T) {
 
 	activation.Limits.Max = 10
 	activation.Limits.Payload = 10
-	activation.Limits.Src = "1.1.1.1"
+	activation.Limits.Src = "192.0.2.0/24"
 	activation.Limits.Times = []TimeRange{
 		{
 			Start: "01:15:00",
@@ -296,7 +296,7 @@ func TestActivationValidation(t *testing.T) {
 		Start: "hello",
 		End:   "03:15:00",
 	}
-	activation.Limits.Src = "1.1.1.1"
+	activation.Limits.Src = "192.0.2.0/24"
 	activation.Limits.Times = append(activation.Limits.Times, tr)
 	vr = CreateValidationResults()
 	activation.Validate(vr)

--- a/types.go
+++ b/types.go
@@ -189,6 +189,7 @@ func (l *Limits) Validate(vr *ValidationResults) {
 		elements := strings.Split(l.Src, ",")
 
 		for _, cidr := range elements {
+			cidr = strings.TrimSpace(cidr)
 			_, ipNet, err := net.ParseCIDR(cidr)
 			if err != nil || ipNet == nil {
 				vr.AddError("invalid cidr %q in user src limits", cidr)

--- a/types.go
+++ b/types.go
@@ -168,6 +168,7 @@ func (tr *TimeRange) Validate(vr *ValidationResults) {
 }
 
 // Limits are used to control acccess for users and importing accounts
+// Src is a comma separated list of CIDR specifications
 type Limits struct {
 	Max     int64       `json:"max,omitempty"`
 	Payload int64       `json:"payload,omitempty"`
@@ -185,10 +186,13 @@ func (l *Limits) Validate(vr *ValidationResults) {
 	}
 
 	if l.Src != "" {
-		ip := net.ParseIP(l.Src)
+		elements := strings.Split(l.Src, ",")
 
-		if ip == nil {
-			vr.AddError("invalid src %q in limits", l.Src)
+		for _, cidr := range elements {
+			_, ipNet, err := net.ParseCIDR(cidr)
+			if err != nil || ipNet == nil {
+				vr.AddError("invalid cidr %q in user src limits", cidr)
+			}
 		}
 	}
 

--- a/user_claims_test.go
+++ b/user_claims_test.go
@@ -343,6 +343,14 @@ func TestSourceNetworkValidation(t *testing.T) {
 		t.Error("limits should be valid")
 	}
 
+	uc.Limits.Src = "192.0.2.0/24 ,\t2001:db8:a0b:12f0::1/32 , 192.168.1.1/1"
+	vr = CreateValidationResults()
+	uc.Validate(vr)
+
+	if !vr.IsEmpty() {
+		t.Error("limits should be valid")
+	}
+
 	uc.Limits.Src = "foo"
 	vr = CreateValidationResults()
 	uc.Validate(vr)

--- a/user_claims_test.go
+++ b/user_claims_test.go
@@ -158,7 +158,7 @@ func TestUserValidation(t *testing.T) {
 	uc.Permissions.Sub.Deny.Add("b")
 	uc.Limits.Max = 10
 	uc.Limits.Payload = 10
-	uc.Limits.Src = "1.1.1.1"
+	uc.Limits.Src = "192.0.2.0/24"
 	uc.Limits.Times = []TimeRange{
 		{
 			Start: "01:15:00",
@@ -215,7 +215,7 @@ func TestUserValidation(t *testing.T) {
 		Start: "hello",
 		End:   "03:15:00",
 	}
-	uc.Limits.Src = "1.1.1.1"
+	uc.Limits.Src = "192.0.2.0/24"
 	uc.Limits.Times = append(uc.Limits.Times, tr)
 	vr = CreateValidationResults()
 	uc.Validate(vr)
@@ -312,5 +312,58 @@ func TestUserAccountIDValidation(t *testing.T) {
 	uc.Validate(&vr)
 	if len(vr.Issues) != 1 {
 		t.Fatal("expected validation issues")
+	}
+}
+
+func TestSourceNetworkValidation(t *testing.T) {
+	ukp := createUserNKey(t)
+	uc := NewUserClaims(publicKey(ukp, t))
+
+	uc.Limits.Src = "192.0.2.0/24"
+	vr := CreateValidationResults()
+	uc.Validate(vr)
+
+	if !vr.IsEmpty() {
+		t.Error("limits should be valid")
+	}
+
+	uc.Limits.Src = "192.0.2.1/1"
+	vr = CreateValidationResults()
+	uc.Validate(vr)
+
+	if !vr.IsEmpty() {
+		t.Error("limits should be valid")
+	}
+
+	uc.Limits.Src = "192.0.2.0/24,2001:db8:a0b:12f0::1/32"
+	vr = CreateValidationResults()
+	uc.Validate(vr)
+
+	if !vr.IsEmpty() {
+		t.Error("limits should be valid")
+	}
+
+	uc.Limits.Src = "foo"
+	vr = CreateValidationResults()
+	uc.Validate(vr)
+
+	if vr.IsEmpty() || len(vr.Issues) != 1 {
+		t.Error("limits should be invalid")
+	}
+
+	uc.Limits.Src = "192.0.2.0/24,foo"
+	vr = CreateValidationResults()
+	uc.Validate(vr)
+
+	if vr.IsEmpty() || len(vr.Issues) != 1 {
+		t.Error("limits should be invalid")
+	}
+
+	uc.Limits.Src = "bloo,foo"
+	vr = CreateValidationResults()
+	uc.Validate(vr)
+
+	if vr.IsEmpty() || len(vr.Issues) != 2 {
+		t.Error("limits should be invalid")
 	}
 }


### PR DESCRIPTION
src network is now a comma separated list of CIDR
This matches NSC

Activation and user use the same limit object. Updated that object and the tests.