### PR TITLE
Removed deferred call to Wipe on decoding creds

### DIFF
--- a/creds_utils.go
+++ b/creds_utils.go
@@ -122,8 +122,6 @@ func FormatUserConfig(jwtString string, seed []byte) ([]byte, error) {
 }
 
 func ParseDecoratedJWT(contents []byte) (string, error) {
-	defer wipeSlice(contents)
-
 	items := userConfigRE.FindAllSubmatch(contents, -1)
 	if len(items) == 0 {
 		return string(contents), nil
@@ -138,7 +136,6 @@ func ParseDecoratedJWT(contents []byte) (string, error) {
 
 func ParseDecoratedNKey(contents []byte) (nkeys.KeyPair, error) {
 	var seed []byte
-	defer wipeSlice(contents)
 
 	items := userConfigRE.FindAllSubmatch(contents, -1)
 	if len(items) > 1 {
@@ -186,11 +183,4 @@ func ParseDecoratedUserNKey(contents []byte) (nkeys.KeyPair, error) {
 		return nil, err
 	}
 	return kp, nil
-}
-
-// Just wipe slice with 'x', for clearing contents of nkey seed file.
-func wipeSlice(buf []byte) {
-	for i := range buf {
-		buf[i] = 'x'
-	}
 }


### PR DESCRIPTION
The client is responsible to call wipe after the contents are processed.