### PR TITLE
Support for latency tracking for exported services

### DIFF
--- a/exports.go
+++ b/exports.go
@@ -38,6 +38,22 @@ const (
 // latency measurements.
 // Sampling 1-100, represents sampling rate, defaults to 100.
 // Results is the subject where the latency metrics are published.
+// A metric will be defined by the nats-server's ServiceLatency. Time durations
+// are in nanoseconds.
+// see https://github.com/nats-io/nats-server/blob/master/server/accounts.go#L524
+// e.g.
+// {
+//  "app": "dlc22",
+//  "start": "2019-09-16T21:46:23.636869585-07:00",
+//  "svc": 219732,
+//  "nats": {
+//    "req": 320415,
+//    "resp": 228268,
+//    "sys": 0
+//  },
+//  "total": 768415
+// }
+//
 type ServiceLatency struct {
 	Sampling int     `json:"sampling,omitempty"`
 	Results  Subject `json:"results"`

--- a/exports_test.go
+++ b/exports_test.go
@@ -231,3 +231,45 @@ func TestExportRevocation(t *testing.T) {
 		t.Errorf("revocation be true we revoked in the future")
 	}
 }
+
+func TestExportTrackLatency(t *testing.T) {
+	e := &Export{Subject: "foo", Type: Service}
+	e.Latency = &ServiceLatency{Sampling: 100, Results: "results"}
+	vr := CreateValidationResults()
+	e.Validate(vr)
+	if !vr.IsEmpty() {
+		t.Errorf("Expected to validate with simple tracking")
+	}
+
+	e = &Export{Subject: "foo", Type: Stream}
+	e.Latency = &ServiceLatency{Sampling: 100, Results: "results"}
+	vr = CreateValidationResults()
+	e.Validate(vr)
+	if vr.IsEmpty() {
+		t.Errorf("adding latency tracking to a stream should have an validation issue")
+	}
+
+	e = &Export{Subject: "foo", Type: Service}
+	e.Latency = &ServiceLatency{Sampling: 0, Results: "results"}
+	vr = CreateValidationResults()
+	e.Validate(vr)
+	if vr.IsEmpty() {
+		t.Errorf("Sampling <1 should have a validation issue")
+	}
+
+	e = &Export{Subject: "foo", Type: Service}
+	e.Latency = &ServiceLatency{Sampling: 122, Results: "results"}
+	vr = CreateValidationResults()
+	e.Validate(vr)
+	if vr.IsEmpty() {
+		t.Errorf("Sampling >100 should have a validation issue")
+	}
+
+	e = &Export{Subject: "foo", Type: Service}
+	e.Latency = &ServiceLatency{Sampling: 22, Results: "results.*"}
+	vr = CreateValidationResults()
+	e.Validate(vr)
+	if vr.IsEmpty() {
+		t.Errorf("Results subject needs to be valid publish subject")
+	}
+}

--- a/header.go
+++ b/header.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// Version is semantic version.
-	Version = "0.2.14"
+	Version = "0.2.16"
 
 	// TokenTypeJwt is the JWT token type supported JWT tokens
 	// encoded and decoded by this library


### PR DESCRIPTION
Added it in same fashion as lib has been built but wondering if we should add helpers.

```go
e.TrackLatency("results")
e.TrackLatencyWithSampling("results", 50)
```

Signed-off-by: Derek Collison <derek@nats.io>