### PR TITLE
moved latency validation code to be associated with it's type

### DIFF
--- a/exports.go
+++ b/exports.go
@@ -59,6 +59,16 @@ type ServiceLatency struct {
 	Results  Subject `json:"results"`
 }
 
+func (sl *ServiceLatency) Validate(vr *ValidationResults) {
+	if sl.Sampling < 1 || sl.Sampling > 100 {
+		vr.AddError("sampling percentage needs to be between 1-100")
+	}
+	sl.Results.Validate(vr)
+	if sl.Results.HasWildCards() {
+		vr.AddError("results subject can not contain wildcards")
+	}
+}
+
 // Export represents a single export
 type Export struct {
 	Name         string          `json:"name,omitempty"`
@@ -111,13 +121,7 @@ func (e *Export) Validate(vr *ValidationResults) {
 		if !e.IsService() {
 			vr.AddError("latency tracking only permitted for services")
 		}
-		if e.Latency.Sampling < 1 || e.Latency.Sampling > 100 {
-			vr.AddError("sampling percentage needs to be between 1-100")
-		}
-		if e.Latency.Results.HasWildCards() {
-			vr.AddError("results subject can not contain wildcards")
-		}
-		e.Latency.Results.Validate(vr)
+		e.Latency.Validate(vr)
 	}
 	e.Subject.Validate(vr)
 }

--- a/header.go
+++ b/header.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// Version is semantic version.
-	Version = "0.2.16"
+	Version = "0.2.18"
 
 	// TokenTypeJwt is the JWT token type supported JWT tokens
 	// encoded and decoded by this library


### PR DESCRIPTION
and thus be able to validate the object directly.