### PR TITLE
service subjects must be unique

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -120,8 +120,18 @@ type Imports []*Import
 
 // Validate checks if an import is valid for the wrapping account
 func (i *Imports) Validate(acctPubKey string, vr *ValidationResults) {
+	m := make(map[Subject]string)
 	for _, v := range *i {
 		v.Validate(acctPubKey, vr)
+		// if it as service, insure that the subject the client is making the request is unique
+		if v.IsService() {
+			c := m[v.Subject]
+			if c != "" {
+				vr.AddError("account already imports a service at %s from account %s", v.Subject, c)
+			} else {
+				m[v.Subject] = v.Account
+			}
+		}
 	}
 }
 

--- a/imports_test.go
+++ b/imports_test.go
@@ -348,3 +348,29 @@ func TestImportSubjectValidation(t *testing.T) {
 		t.Errorf("imports with valid contains subject should be valid")
 	}
 }
+
+func Test_ServiceSubjectsUnique(t *testing.T) {
+	apk := publicKey(createAccountNKey(t), t)
+	bpk := publicKey(createAccountNKey(t), t)
+	cpk := publicKey(createAccountNKey(t), t)
+
+	var srvImports Imports
+	srvImports.Add(&Import{Subject: "a", Account: bpk, To: "q", Type: Service})
+	srvImports.Add(&Import{Subject: "a", Account: cpk, To: "qq", Type: Service})
+
+	vr := CreateValidationResults()
+	srvImports.Validate(apk, vr)
+	if !vr.IsBlocking(true) {
+		t.Error("expected validation to fail with duplicate service subject")
+	}
+
+	var streamImports Imports
+	streamImports.Add(&Import{Subject: "a", Account: bpk, To: "q", Type: Stream})
+	streamImports.Add(&Import{Subject: "a", Account: cpk, To: "qq", Type: Stream})
+
+	vr = CreateValidationResults()
+	streamImports.Validate(apk, vr)
+	if vr.IsBlocking(true) {
+		t.Errorf("didn't expect validation problems: %v", vr.Issues[0])
+	}
+}


### PR DESCRIPTION
Service client defines the subject they can publish requests to. This subject must be unique.