### PR TITLE
Added sorting of imports and exports on account claim encoding

### DIFF
--- a/account_claims.go
+++ b/account_claims.go
@@ -17,6 +17,7 @@ package jwt
 
 import (
 	"errors"
+	"sort"
 	"time"
 
 	"github.com/nats-io/nkeys"
@@ -127,7 +128,8 @@ func (a *AccountClaims) Encode(pair nkeys.KeyPair) (string, error) {
 	if !nkeys.IsValidPublicAccountKey(a.Subject) {
 		return "", errors.New("expected subject to be account public key")
 	}
-
+	sort.Sort(a.Exports)
+	sort.Sort(a.Imports)
 	a.ClaimsData.Type = AccountClaim
 	return a.ClaimsData.Encode(pair, a)
 }

--- a/exports.go
+++ b/exports.go
@@ -158,7 +158,7 @@ func (e *Export) IsRevoked(pubKey string) bool {
 	return e.Revocations.IsRevoked(pubKey, time.Now())
 }
 
-// Exports is an array of exports
+// Exports is a slice of exports
 type Exports []*Export
 
 // Add appends exports to the list
@@ -221,4 +221,16 @@ func (e *Exports) HasExportContainingSubject(subject Subject) bool {
 		}
 	}
 	return false
+}
+
+func (e Exports) Len() int {
+	return len(e)
+}
+
+func (e Exports) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+}
+
+func (e Exports) Less(i, j int) bool {
+	return e[i].Subject < e[j].Subject
 }

--- a/exports_test.go
+++ b/exports_test.go
@@ -16,6 +16,7 @@
 package jwt
 
 import (
+	"sort"
 	"testing"
 	"time"
 )
@@ -271,5 +272,19 @@ func TestExportTrackLatency(t *testing.T) {
 	e.Validate(vr)
 	if vr.IsEmpty() {
 		t.Errorf("Results subject needs to be valid publish subject")
+	}
+}
+
+func TestExport_Sorting(t *testing.T) {
+	var exports Exports
+	exports.Add(&Export{Subject: "x", Type: Service})
+	exports.Add(&Export{Subject: "z", Type: Service})
+	exports.Add(&Export{Subject: "y", Type: Service})
+	if exports[0].Subject != "x" {
+		t.Fatal("added export not in expected order")
+	}
+	sort.Sort(exports)
+	if exports[0].Subject != "x" && exports[1].Subject != "y" && exports[2].Subject != "z" {
+		t.Fatal("exports not sorted")
 	}
 }

--- a/imports.go
+++ b/imports.go
@@ -136,3 +136,15 @@ func (i *Imports) Validate(acctPubKey string, vr *ValidationResults) {
 func (i *Imports) Add(a ...*Import) {
 	*i = append(*i, a...)
 }
+
+func (i Imports) Len() int {
+	return len(i)
+}
+
+func (i Imports) Swap(j, k int) {
+	i[j], i[k] = i[k], i[j]
+}
+
+func (i Imports) Less(j, k int) bool {
+	return i[j].Subject < i[k].Subject
+}

--- a/imports_test.go
+++ b/imports_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
 	"time"
 )
@@ -375,5 +376,20 @@ func TestImportServiceDoubleToSubjectsValidation(t *testing.T) {
 
 	if !vr.IsBlocking(true) {
 		t.Fatalf("Expected multiple import 'to' subjects to produce an error")
+	}
+}
+
+func TestImport_Sorting(t *testing.T) {
+	var imports Imports
+	pk := publicKey(createAccountNKey(t), t)
+	imports.Add(&Import{Subject: "x", Type: Service, Account: pk})
+	imports.Add(&Import{Subject: "z", Type: Service, Account: pk})
+	imports.Add(&Import{Subject: "y", Type: Service, Account: pk})
+	if imports[0].Subject != "x" {
+		t.Fatal("added import not in expected order")
+	}
+	sort.Sort(imports)
+	if imports[0].Subject != "x" && imports[1].Subject != "y" && imports[2].Subject != "z" {
+		t.Fatal("imports not sorted")
 	}
 }


### PR DESCRIPTION
sorting the imports and exports by subject makes it easier to scan the import/exports when describing, selecting and manipulating them.