### PR TITLE
Fix creds parsing on files that have had their line endings changed to CRLFs.

### DIFF
--- a/creds_utils.go
+++ b/creds_utils.go
@@ -82,7 +82,7 @@ NKEYs are sensitive and should be treated as secrets.
 	return w.Bytes(), nil
 }
 
-var userConfigRE = regexp.MustCompile(`\s*(?:(?:[-]{3,}[^\n]*[-]{3,}\n)(.+)(?:\n\s*[-]{3,}[^\n]*[-]{3,}\n))`)
+var userConfigRE = regexp.MustCompile(`\s*(?:(?:[-]{3,}.*[-]{3,}\r?\n)([\w\-.=]+)(?:\r?\n[-]{3,}.*[-]{3,}\r?\n))`)
 
 // An user config file looks like this:
 //  -----BEGIN NATS USER JWT-----

--- a/creds_utils_test.go
+++ b/creds_utils_test.go
@@ -209,3 +209,66 @@ func Test_DecorateNKeys(t *testing.T) {
 		t.Fatal("required error parsing bad nkey")
 	}
 }
+
+func Test_ParseCreds(t *testing.T) {
+	token, kp := makeJWT(t)
+	d, err := FormatUserConfig(token, seedKey(kp, t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pk, err := kp.PublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token2, err := ParseDecoratedJWT(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != token2 {
+		t.Fatal("expected jwts to match")
+	}
+	kp2, err := ParseDecoratedUserNKey(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pk2, err := kp2.PublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pk != pk2 {
+		t.Fatal("expected keys to match")
+	}
+}
+
+func Test_ParseCredsWithCrLfs(t *testing.T) {
+	token, kp := makeJWT(t)
+	d, err := FormatUserConfig(token, seedKey(kp, t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pk, err := kp.PublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	d = bytes.ReplaceAll(d, []byte{'\n'}, []byte{'\r', '\n'})
+
+	token2, err := ParseDecoratedJWT(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != token2 {
+		t.Fatal("expected jwts to match")
+	}
+	kp2, err := ParseDecoratedUserNKey(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pk2, err := kp2.PublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pk != pk2 {
+		t.Fatal("expected keys to match")
+	}
+}


### PR DESCRIPTION
FIX #71 - Relaxed regex to allow optional carriage returns. Target content also had to change from `.+`, to more specifically grab the non-whitespace content.

Note that this regex is fairly complicated, an alternative fix simply strips carriage returns from the input before parsing. I am OK with doing that change instead, as this required quite a bit of staring (with Matthias).