### PR TITLE
Add jetstream account specific limits and group existing ones

### DIFF
--- a/v2/account_claims.go
+++ b/v2/account_claims.go
@@ -26,16 +26,32 @@ import (
 // NoLimit is used to indicate a limit field is unlimited in value.
 const NoLimit = -1
 
-// OperatorLimits are used to limit access by an account
-type OperatorLimits struct {
-	Subs            int64 `json:"subs,omitempty"`      // Max number of subscriptions
-	Conn            int64 `json:"conn,omitempty"`      // Max number of active connections
-	LeafNodeConn    int64 `json:"leaf,omitempty"`      // Max number of active leaf node connections
+type AccountLimits struct {
 	Imports         int64 `json:"imports,omitempty"`   // Max number of imports
 	Exports         int64 `json:"exports,omitempty"`   // Max number of exports
-	Data            int64 `json:"data,omitempty"`      // Max number of bytes
-	Payload         int64 `json:"payload,omitempty"`   // Max message payload
 	WildcardExports bool  `json:"wildcards,omitempty"` // Are wildcards allowed in exports
+}
+
+type NatsLimits struct {
+	Subs         int64 `json:"subs,omitempty"`    // Max number of subscriptions
+	Conn         int64 `json:"conn,omitempty"`    // Max number of active connections
+	LeafNodeConn int64 `json:"leaf,omitempty"`    // Max number of active leaf node connections
+	Data         int64 `json:"data,omitempty"`    // Max number of bytes
+	Payload      int64 `json:"payload,omitempty"` // Max message payload
+}
+
+type JetStreamLimits struct {
+	MemoryStorage int64 `json:"mem_storage,omitempty"`  // Max number of bytes stored in memory across all streams. (0 means disabled)
+	DiskStorage   int64 `json:"disk_storage,omitempty"` // Max number of bytes stored on disk across all streams. (0 means disabled)
+	Streams       int64 `json:"streams,omitempty"`      // Max number of streams
+	Consumer      int64 `json:"consumer,omitempty"`     // Max number of consumer
+}
+
+// OperatorLimits are used to limit access by an account
+type OperatorLimits struct {
+	NatsLimits
+	AccountLimits
+	JetStreamLimits
 }
 
 // IsEmpty returns true if all of the limits are 0/false.
@@ -45,7 +61,10 @@ func (o *OperatorLimits) IsEmpty() bool {
 
 // IsUnlimited returns true if all limits are
 func (o *OperatorLimits) IsUnlimited() bool {
-	return *o == OperatorLimits{NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, true}
+	return *o == OperatorLimits{
+		NatsLimits{NoLimit, NoLimit, NoLimit, NoLimit, NoLimit},
+		AccountLimits{NoLimit, NoLimit, true},
+		JetStreamLimits{NoLimit, NoLimit, NoLimit, NoLimit}}
 }
 
 // Validate checks that the operator limits contain valid values
@@ -121,7 +140,10 @@ func NewAccountClaims(subject string) *AccountClaims {
 	c := &AccountClaims{}
 	// Set to unlimited to start. We do it this way so we get compiler
 	// errors if we add to the OperatorLimits.
-	c.Limits = OperatorLimits{NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, NoLimit, true}
+	c.Limits = OperatorLimits{
+		NatsLimits{NoLimit, NoLimit, NoLimit, NoLimit, NoLimit},
+		AccountLimits{NoLimit, NoLimit, true},
+		JetStreamLimits{NoLimit, NoLimit, NoLimit, NoLimit}}
 	c.Subject = subject
 	return c
 }

--- a/v2/account_claims_test.go
+++ b/v2/account_claims_test.go
@@ -354,6 +354,31 @@ func TestWildcardExportLimit(t *testing.T) {
 	}
 }
 
+func TestJetstreamLimits(t *testing.T) {
+	akp := createAccountNKey(t)
+	apk := publicKey(akp, t)
+	acc1 := NewAccountClaims(apk)
+	if !acc1.Limits.IsUnlimited() {
+		t.Fatal()
+	}
+	acc1.Limits.Consumer = 1
+	acc1.Limits.Streams = 2
+	acc1.Limits.MemoryStorage = 3
+	acc1.Limits.DiskStorage = 4
+	vr := CreateValidationResults()
+	acc1.Validate(vr)
+	if !vr.IsEmpty() {
+		t.Fatal("valid account should have no validation issues")
+	}
+	if token, err := acc1.Encode(akp); err != nil {
+		t.Fatal("valid account should have no validation issues")
+	} else if acc2, err := DecodeAccountClaims(token); err != nil {
+		t.Fatal("valid account should have no validation issues")
+	} else if acc1.Limits.JetStreamLimits != acc2.Limits.JetStreamLimits {
+		t.Fatal("account should have same properties")
+	}
+}
+
 func TestAccountSigningKeyValidation(t *testing.T) {
 	okp := createOperatorNKey(t)
 


### PR DESCRIPTION
Grouping as done here can be transparent to users as long as member names don't overlap.

Signed-off-by: Matthias Hanel <mh@synadia.com>

