### PR TITLE
New User Limits need to default to NoLimit when read from jwt V1

### DIFF
--- a/v2/decoder_migration_test.go
+++ b/v2/decoder_migration_test.go
@@ -211,6 +211,9 @@ func TestMigrateUser(t *testing.T) {
 	AssertNoError(err, t)
 	uc2, ok := c.(*UserClaims)
 	AssertTrue(ok, t)
+	AssertTrue(uc2.Limits.Payload == NoLimit, t)
+	AssertTrue(uc2.Limits.Subs == NoLimit, t)
+	AssertTrue(uc2.Limits.Data == NoLimit, t)
 
 	equalUsers(t, uc, uc2)
 }

--- a/v2/decoder_user.go
+++ b/v2/decoder_user.go
@@ -18,6 +18,8 @@ package jwt
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/nats-io/jwt"
 )
 
 type v1User struct {
@@ -43,6 +45,7 @@ func loadUser(data []byte, version int) (*UserClaims, error) {
 	switch version {
 	case 1:
 		var v1a v1UserClaims
+		v1a.Limits = Limits{NatsLimits: NatsLimits{jwt.NoLimit, jwt.NoLimit, jwt.NoLimit}}
 		v1a.Max = NoLimit
 		if err := json.Unmarshal(data, &v1a); err != nil {
 			return nil, err


### PR DESCRIPTION
these fields are not present in V1 and ended up being 0.
had to set them to NoLimit when reading from V1.

Signed-off-by: Matthias Hanel <mh@synadia.com>