### PR TITLE
[ADDED] AllowedConnectionTypes in UserClaims

### DIFF
--- a/v2/user_claims.go
+++ b/v2/user_claims.go
@@ -25,7 +25,8 @@ import (
 type User struct {
 	Permissions
 	Limits
-	BearerToken bool `json:"bearer_token,omitempty"`
+	BearerToken            bool                `json:"bearer_token,omitempty"`
+	AllowedConnectionTypes map[string]struct{} `json:"allowed_connection_types,omitempty"`
 	// IssuerAccount stores the public key for the account the issuer represents.
 	// When set, the claim was issued by a signing key.
 	IssuerAccount string `json:"issuer_account,omitempty"`

--- a/v2/user_claims.go
+++ b/v2/user_claims.go
@@ -21,12 +21,18 @@ import (
 	"github.com/nats-io/nkeys"
 )
 
+const (
+	ConnectionTypeStandard  = "STANDARD"
+	ConnectionTypeWebsocket = "WEBSOCKET"
+	ConnectionTypeLeafnode  = "LEAFNODE"
+)
+
 // User defines the user specific data in a user JWT
 type User struct {
 	Permissions
 	Limits
-	BearerToken            bool                `json:"bearer_token,omitempty"`
-	AllowedConnectionTypes map[string]struct{} `json:"allowed_connection_types,omitempty"`
+	BearerToken            bool       `json:"bearer_token,omitempty"`
+	AllowedConnectionTypes StringList `json:"allowed_connection_types,omitempty"`
 	// IssuerAccount stores the public key for the account the issuer represents.
 	// When set, the claim was issued by a signing key.
 	IssuerAccount string `json:"issuer_account,omitempty"`

--- a/v2/user_claims_test.go
+++ b/v2/user_claims_test.go
@@ -350,3 +350,19 @@ func TestSourceNetworkValidation(t *testing.T) {
 		t.Error("limits should be invalid")
 	}
 }
+
+func TestUserAllowedConnectionTypes(t *testing.T) {
+	ukp := createUserNKey(t)
+	uc := NewUserClaims(publicKey(ukp, t))
+
+	vr := CreateValidationResults()
+	uc.Validate(vr)
+
+	uc.AllowedConnectionTypes = map[string]struct{}{"WEBSOCKET": struct{}{}}
+	vr = CreateValidationResults()
+	uc.Validate(vr)
+
+	uc.AllowedConnectionTypes = map[string]struct{}{"anything": struct{}{}, "WEBSOCKET": struct{}{}}
+	vr = CreateValidationResults()
+	uc.Validate(vr)
+}

--- a/v2/user_claims_test.go
+++ b/v2/user_claims_test.go
@@ -352,17 +352,18 @@ func TestSourceNetworkValidation(t *testing.T) {
 }
 
 func TestUserAllowedConnectionTypes(t *testing.T) {
+	akp := createAccountNKey(t)
 	ukp := createUserNKey(t)
+
 	uc := NewUserClaims(publicKey(ukp, t))
+	uc.AllowedConnectionTypes.Add(ConnectionTypeStandard)
+	uc.AllowedConnectionTypes.Add(ConnectionTypeWebsocket)
+	uJwt := encode(uc, akp, t)
 
-	vr := CreateValidationResults()
-	uc.Validate(vr)
-
-	uc.AllowedConnectionTypes = map[string]struct{}{"WEBSOCKET": struct{}{}}
-	vr = CreateValidationResults()
-	uc.Validate(vr)
-
-	uc.AllowedConnectionTypes = map[string]struct{}{"anything": struct{}{}, "WEBSOCKET": struct{}{}}
-	vr = CreateValidationResults()
-	uc.Validate(vr)
+	uc2, err := DecodeUserClaims(uJwt)
+	if err != nil {
+		t.Fatal("failed to decode uc", err)
+	}
+	AssertTrue(uc2.AllowedConnectionTypes.Contains(ConnectionTypeStandard), t)
+	AssertTrue(uc2.AllowedConnectionTypes.Contains(ConnectionTypeWebsocket), t)
 }


### PR DESCRIPTION
This would be used by the server to restrict the connections
from the kind of clients that are found in the map, if the map
is not empty.
In other words, an empty map means no restriction (which also
allows backward compatibility).
If the map is not empty, then when a client connects, if the
user is found, the server will check that the type of client
(say standard, or websocket) is found in this map. If not, the
connection will be rejected.

I am not set on either the name or the type. It could be an
array of string and I will convert to a map[string]struct{}
in the server when processing the JWT.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>