### PR TITLE
[Fixed] nil import/export on Validate issue

### DIFF
--- a/exports.go
+++ b/exports.go
@@ -109,6 +109,10 @@ func (e *Export) IsStreamResponse() bool {
 
 // Validate appends validation issues to the passed in results list
 func (e *Export) Validate(vr *ValidationResults) {
+	if e == nil {
+		vr.AddError("null export is not allowed")
+		return
+	}
 	if !e.IsService() && !e.IsStream() {
 		vr.AddError("invalid export type: %q", e.Type)
 	}
@@ -200,6 +204,10 @@ func (e *Exports) Validate(vr *ValidationResults) error {
 	var streamSubjects []Subject
 
 	for _, v := range *e {
+		if v == nil {
+			vr.AddError("null export is not allowed")
+			continue
+		}
 		if v.IsService() {
 			serviceSubjects = append(serviceSubjects, v.Subject)
 		} else {

--- a/imports.go
+++ b/imports.go
@@ -53,6 +53,10 @@ func (i *Import) IsStream() bool {
 
 // Validate checks if an import is valid for the wrapping account
 func (i *Import) Validate(actPubKey string, vr *ValidationResults) {
+	if i == nil {
+		vr.AddError("null import is not allowed")
+		return
+	}
 	if !i.IsService() && !i.IsStream() {
 		vr.AddError("invalid import type: %q", i.Type)
 	}
@@ -123,6 +127,10 @@ type Imports []*Import
 func (i *Imports) Validate(acctPubKey string, vr *ValidationResults) {
 	toSet := make(map[Subject]bool, len(*i))
 	for _, v := range *i {
+		if v == nil {
+			vr.AddError("null import is not allowed")
+			continue
+		}
 		if v.Type == Service {
 			if _, ok := toSet[v.To]; ok {
 				vr.AddError("Duplicate To subjects for %q", v.To)

--- a/v2/exports.go
+++ b/v2/exports.go
@@ -228,6 +228,10 @@ func (e *Exports) Validate(vr *ValidationResults) error {
 	var streamSubjects []Subject
 
 	for _, v := range *e {
+		if v == nil {
+			vr.AddError("null export is not allowed")
+			continue
+		}
 		if v.IsService() {
 			serviceSubjects = append(serviceSubjects, v.Subject)
 		} else {

--- a/v2/imports.go
+++ b/v2/imports.go
@@ -127,6 +127,10 @@ type Imports []*Import
 func (i *Imports) Validate(acctPubKey string, vr *ValidationResults) {
 	toSet := make(map[Subject]bool, len(*i))
 	for _, v := range *i {
+		if v == nil {
+			vr.AddError("null import is not allowed")
+			continue
+		}
 		if v.Type == Service {
 			if _, ok := toSet[v.To]; ok {
 				vr.AddError("Duplicate To subjects for %q", v.To)


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

JWTV2 already has the check for in Export/Import Validate, just realized that the pointer is touched in Imports/Exports too.
Since Export/Import have a public Validate as well, I check there as well as in Imports/Exports

@aricart saw that first 
