### PR TITLE
Have IsRevoked check inclusive not exclusive

### DIFF
--- a/revocation_list.go
+++ b/revocation_list.go
@@ -43,5 +43,5 @@ func (r RevocationList) ClearRevocation(pubKey string) {
 // be used for testing.
 func (r RevocationList) IsRevoked(pubKey string, timestamp time.Time) bool {
 	ts, ok := r[pubKey]
-	return ok && ts > timestamp.Unix()
+	return ok && ts >= timestamp.Unix()
 }

--- a/v2/revocation_list.go
+++ b/v2/revocation_list.go
@@ -43,5 +43,5 @@ func (r RevocationList) ClearRevocation(pubKey string) {
 // be used for testing.
 func (r RevocationList) IsRevoked(pubKey string, timestamp time.Time) bool {
 	ts, ok := r[pubKey]
-	return ok && ts > timestamp.Unix()
+	return ok && ts >= timestamp.Unix()
 }


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

The second resolution makes tests harder than need be.
This changed the timestamp to mean inclusive.