### PR TITLE
[ADDED] IsClaimRevoked to check user claim and fixed some comments.

### DIFF
--- a/account_claims.go
+++ b/account_claims.go
@@ -194,7 +194,8 @@ func (a *AccountClaims) Revoke(pubKey string) {
 	a.RevokeAt(pubKey, time.Now())
 }
 
-// RevokeAt enters a revocation by publickey and timestamp into this export
+// RevokeAt enters a revocation by public key and timestamp into this account
+// This will revoke all jwt issued for pubKey, prior to timestamp
 // If there is already a revocation for this public key that is newer, it is kept.
 func (a *AccountClaims) RevokeAt(pubKey string, timestamp time.Time) {
 	if a.Revocations == nil {
@@ -209,14 +210,23 @@ func (a *AccountClaims) ClearRevocation(pubKey string) {
 	a.Revocations.ClearRevocation(pubKey)
 }
 
-// IsRevokedAt checks if the public key is in the revoked list with a timestamp later than
-// the one passed in. Generally this method is called with time.Now() but other time's can
-// be used for testing.
+// IsRevokedAt checks if the public key is in the revoked list with a timestamp later than the one passed in.
+// Generally this method is called with the subject and issue time of the jwt to be tested.
+// DO NOT pass time.Now(), it will not produce a stable/expected response.
 func (a *AccountClaims) IsRevokedAt(pubKey string, timestamp time.Time) bool {
 	return a.Revocations.IsRevoked(pubKey, timestamp)
 }
 
-// IsRevoked checks if the public key is in the revoked list with time.Now()
-func (a *AccountClaims) IsRevoked(pubKey string) bool {
-	return a.Revocations.IsRevoked(pubKey, time.Now())
+// IsRevoked does not perform a valid check. Use IsRevokedAt instead.
+func (a *AccountClaims) IsRevoked(_ string) bool {
+	return true
+}
+
+// IsClaimRevoked checks if the account revoked the claim passed in.
+// Invalid claims (nil, no Subject or IssuedAt) will return true.
+func (a *AccountClaims) IsClaimRevoked(claim *UserClaims) bool {
+	if claim == nil || claim.IssuedAt == 0 || claim.Subject == "" {
+		return true
+	}
+	return a.Revocations.IsRevoked(claim.Subject, time.Unix(claim.IssuedAt, 0))
 }

--- a/account_claims_test.go
+++ b/account_claims_test.go
@@ -488,7 +488,14 @@ func TestUserRevocation(t *testing.T) {
 	apk := publicKey(akp, t)
 	account := NewAccountClaims(apk)
 
-	pubKey := "bar"
+	ukp := createUserNKey(t)
+	pubKey := publicKey(ukp, t)
+	uc := NewUserClaims(pubKey)
+	uJwt, _ := uc.Encode(akp)
+	uc, err := DecodeUserClaims(uJwt)
+	if err != nil {
+		t.Errorf("Failed to decode user claim: %v", err)
+	}
 	now := time.Now()
 
 	// test that clear is safe before we add any
@@ -523,13 +530,13 @@ func TestUserRevocation(t *testing.T) {
 
 	account.ClearRevocation(pubKey)
 
-	if account.IsRevokedAt(pubKey, now) {
+	if account.IsClaimRevoked(uc) {
 		t.Errorf("revocations should be cleared")
 	}
 
 	account.RevokeAt(pubKey, now.Add(time.Second*1000))
 
-	if !account.IsRevoked(pubKey) {
+	if !account.IsClaimRevoked(uc) {
 		t.Errorf("revocation be true we revoked in the future")
 	}
 }

--- a/revocation_list.go
+++ b/revocation_list.go
@@ -24,7 +24,7 @@ func (r RevocationList) ClearRevocation(pubKey string) {
 }
 
 // IsRevoked checks if the public key is in the revoked list with a timestamp later than
-// the one passed in. Generally this method is called with time.Now() but other time's can
+// the one passed in. Generally this method is called with an issue time but other time's can
 // be used for testing.
 func (r RevocationList) IsRevoked(pubKey string, timestamp time.Time) bool {
 	ts, ok := r[pubKey]


### PR DESCRIPTION
Comment for RevokeAt(), IsRevokedAt() have been fixed.

The function IsRevoked() must no longer be used (and removed in v2).
It will now always return `true`. Use IsRevokedAt() instead with
proper timestamp.

This is a port of #103

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>