### PR TITLE
[ADDED] IsClaimRevoked to check user claim and fixed some comments.

### DIFF
--- a/account_claims.go
+++ b/account_claims.go
@@ -221,3 +221,12 @@ func (a *AccountClaims) IsRevokedAt(pubKey string, timestamp time.Time) bool {
 func (a *AccountClaims) IsRevoked(_ string) bool {
 	return true
 }
+
+// IsClaimRevoked checks if the account revoked the claim passed in.
+// Invalid claims (nil, no Subject or IssuedAt) will return true.
+func (a *AccountClaims) IsClaimRevoked(claim *UserClaims) bool {
+	if claim == nil || claim.IssuedAt == 0 || claim.Subject == "" {
+		return true
+	}
+	return a.Revocations.IsRevoked(claim.Subject, time.Unix(claim.IssuedAt, 0))
+}

--- a/account_claims_test.go
+++ b/account_claims_test.go
@@ -488,7 +488,14 @@ func TestUserRevocation(t *testing.T) {
 	apk := publicKey(akp, t)
 	account := NewAccountClaims(apk)
 
-	pubKey := "bar"
+	ukp := createUserNKey(t)
+	pubKey := publicKey(ukp, t)
+	uc := NewUserClaims(pubKey)
+	uJwt, _ := uc.Encode(akp)
+	uc, err := DecodeUserClaims(uJwt)
+	if err != nil {
+		t.Errorf("Failed to decode user claim: %v", err)
+	}
 	now := time.Now()
 
 	// test that clear is safe before we add any
@@ -523,13 +530,13 @@ func TestUserRevocation(t *testing.T) {
 
 	account.ClearRevocation(pubKey)
 
-	if account.IsRevokedAt(pubKey, now) {
+	if account.IsClaimRevoked(uc) {
 		t.Errorf("revocations should be cleared")
 	}
 
 	account.RevokeAt(pubKey, now.Add(time.Second*1000))
 
-	if !account.IsRevoked(pubKey) {
+	if !account.IsClaimRevoked(uc) {
 		t.Errorf("revocation be true we revoked in the future")
 	}
 }

--- a/revocation_list.go
+++ b/revocation_list.go
@@ -39,7 +39,7 @@ func (r RevocationList) ClearRevocation(pubKey string) {
 }
 
 // IsRevoked checks if the public key is in the revoked list with a timestamp later than
-// the one passed in. Generally this method is called with time.Now() but other time's can
+// the one passed in. Generally this method is called with an issue time but other time's can
 // be used for testing.
 func (r RevocationList) IsRevoked(pubKey string, timestamp time.Time) bool {
 	ts, ok := r[pubKey]


### PR DESCRIPTION
Comment for RevokeAt(), IsRevokedAt() have been fixed.

The function IsRevoked() must no longer be used (and removed in v2).
It will now always return true. Use IsRevokedAt() instead with
proper timestamp.

Note: This was done in v2 and backported to branch_v1 but was not
added to the v1 in the main branch. So this is a port of #108.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>