### PR TITLE
Removed bogus test that was matching source version.

### DIFF
--- a/header.go
+++ b/header.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// Version is semantic version.
-	Version = "1.0.1"
+	Version = "1.1.2"
 
 	// TokenTypeJwt is the JWT token type supported JWT tokens
 	// encoded and decoded by this library

--- a/types_test.go
+++ b/types_test.go
@@ -16,7 +16,6 @@
 package jwt
 
 import (
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -27,23 +26,6 @@ func TestVersion(t *testing.T) {
 	verRe := regexp.MustCompile(`\d+.\d+.\d+(-\S+)?`)
 	if !verRe.MatchString(Version) {
 		t.Fatalf("Version not compatible with semantic versioning: %q", Version)
-	}
-}
-
-func TestVersionMatchesTag(t *testing.T) {
-	tag := os.Getenv("TRAVIS_TAG")
-	if tag == "" {
-		t.SkipNow()
-	}
-	// We expect a tag of the form vX.Y.Z. If that's not the case,
-	// we need someone to have a look. So fail if first letter is not
-	// a `v`
-	if tag[0] != 'v' {
-		t.Fatalf("Expect tag to start with `v`, tag is: %s", tag)
-	}
-	// Strip the `v` from the tag for the version comparison.
-	if Version != tag[1:] {
-		t.Fatalf("Version (%s) does not match tag (%s)", Version, tag[1:])
 	}
 }
 

--- a/v2/header.go
+++ b/v2/header.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// Version is semantic version.
-	Version = "0.3.2"
+	Version = "1.1.2"
 
 	// TokenTypeJwt is the JWT token type supported JWT tokens
 	// encoded and decoded by this library

--- a/v2/types_test.go
+++ b/v2/types_test.go
@@ -16,7 +16,6 @@
 package jwt
 
 import (
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -27,23 +26,6 @@ func TestVersion(t *testing.T) {
 	verRe := regexp.MustCompile(`\d+.\d+.\d+(-\S+)?`)
 	if !verRe.MatchString(Version) {
 		t.Fatalf("Version not compatible with semantic versioning: %q", Version)
-	}
-}
-
-func TestVersionMatchesTag(t *testing.T) {
-	tag := os.Getenv("TRAVIS_TAG")
-	if tag == "" {
-		t.SkipNow()
-	}
-	// We expect a tag of the form vX.Y.Z. If that's not the case,
-	// we need someone to have a look. So fail if first letter is not
-	// a `v`
-	if tag[0] != 'v' {
-		t.Fatalf("Expect tag to start with `v`, tag is: %s", tag)
-	}
-	// Strip the `v` from the tag for the version comparison.
-	if Version != tag[1:] {
-		t.Fatalf("Version (%s) does not match tag (%s)", Version, tag[1:])
 	}
 }
 


### PR DESCRIPTION
The previous check-in activated testing for v2, which then ran a test that matches the git tag - this is a bogus test, especially when we are dealing with modules that clamp to a particular tag.