### PR TITLE
Changed error when v1 parses v2 and fixed v2 generic claim migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/nats-io/jwt
 
-require (
-	github.com/nats-io/nkeys v0.2.0
-)
+require github.com/nats-io/nkeys v0.2.0
 
 go 1.14

--- a/header.go
+++ b/header.go
@@ -64,7 +64,10 @@ func (h *Header) Valid() error {
 		return fmt.Errorf("not supported type %q", h.Type)
 	}
 
-	if AlgorithmNkey != strings.ToLower(h.Algorithm) {
+	if alg := strings.ToLower(h.Algorithm); alg != AlgorithmNkey {
+		if alg == "ed25519-nkey" {
+			return fmt.Errorf("more recent jwt version")
+		}
 		return fmt.Errorf("unexpected %q algorithm", h.Algorithm)
 	}
 	return nil

--- a/operator_claims_test.go
+++ b/operator_claims_test.go
@@ -398,7 +398,7 @@ func Test_ForwardCompatibility(t *testing.T) {
 	newOp := `eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJqdGkiOiJTSUYyR0ZRSEhWWUtDQlZYRklYUURYV1FCQUcyWEw3SVZLVVJZT0ZTWlhVT0tTRUpLWDdBIiwiaWF0IjoxNTkwNTI0NTAwLCJpc3MiOiJPQlQ2REtGSzQ2STM3TjdCUkwyUkpMVVJLWUdSQTZBWVJQREFISFFFQUFBR05ZWExNR1JEUEtMQyIsInN1YiI6Ik9CVDZES0ZLNDZJMzdON0JSTDJSSkxVUktZR1JBNkFZUlBEQUhIUUVBQUFHTllYTE1HUkRQS0xDIiwibmF0cyI6eyJ0YWdzIjpbIm9uZSIsInR3byIsInRocmVlIl0sInR5cGUiOiJvcGVyYXRvciIsInZlcnNpb24iOjJ9fQ.u6JFiISIh2o-CWxktfEw3binmCLhLaFVMyuIa2HNo_x_6EGWVPVICVWc_MOLFS-6Nm17Cj4SmOh3zUtlTRkfDA`
 	if _, err := DecodeOperatorClaims(newOp); err == nil {
 		t.Fatal("Expected error")
-	} else if err.Error() != `unexpected "ed25519-nkey" algorithm` {
+	} else if err.Error() != `more recent jwt version` {
 		t.Fatal("Expected different error, got: ", err)
 	}
 }

--- a/v2/decoder_migration_test.go
+++ b/v2/decoder_migration_test.go
@@ -241,6 +241,27 @@ func TestMigrateUserWithDeprecatedLimits(t *testing.T) {
 	AssertNoError(err, t)
 }
 
+func TestMigrateUserToGeneric(t *testing.T) {
+	ukp, err := nkeys.CreateUser()
+	AssertNoError(err, t)
+	upk, err := ukp.PublicKey()
+	AssertNoError(err, t)
+	akp, err := nkeys.CreateAccount()
+	AssertNoError(err, t)
+	uc := v1jwt.NewUserClaims(upk)
+	uc.Name = "U"
+	uc.Audience = "Audience"
+	uc.Max = 1
+	uc.Tags = []string{"foo", "bar"}
+
+	tok, err := uc.Encode(akp)
+	AssertNoError(err, t)
+	uc2, err := DecodeGeneric(tok)
+	AssertNoError(err, t)
+	AssertTrue(string(uc2.ClaimType()) == string(uc.Type), t)
+	AssertTrue(uc2.Data["tags"].(TagList)[0] == uc.Tags[0], t)
+}
+
 func TestMigrateActivationWithDeprecatedLimits(t *testing.T) {
 	akp, err := nkeys.CreateAccount()
 	AssertNoError(err, t)


### PR DESCRIPTION
was dropping type and tag fields

Signed-off-by: Matthias Hanel <mh@synadia.com>