### PR TITLE
fix generic claim type on upgrade from v1 to be a string

### DIFF
--- a/v2/genericlaims.go
+++ b/v2/genericlaims.go
@@ -78,7 +78,10 @@ func DecodeGeneric(token string) (*GenericClaims, error) {
 			return nil, errors.New("claim failed V1 signature verification")
 		}
 		if tp := gc.GenericFields.Type; tp != "" {
-			gc.GenericClaims.Data["type"] = tp
+			// the conversion needs to be from a string because
+			// on custom types the type is not going to be one of
+			// the constants
+			gc.GenericClaims.Data["type"] = string(tp)
 		}
 		if tp := gc.GenericFields.Tags; len(tp) != 0 {
 			gc.GenericClaims.Data["tags"] = tp


### PR DESCRIPTION
insured that genericclaims type is a string, so we properly can identify custom generic jwt types as generic on their "ClaimType".