### PR TITLE
op.DidSign(op) was broken when strict sk usage was enforced

### DIFF
--- a/v2/operator_claims.go
+++ b/v2/operator_claims.go
@@ -166,6 +166,7 @@ func NewOperatorClaims(subject string) *OperatorClaims {
 	}
 	c := &OperatorClaims{}
 	c.Subject = subject
+	c.Issuer = subject
 	return c
 }
 
@@ -176,7 +177,10 @@ func (oc *OperatorClaims) DidSign(op Claims) bool {
 	}
 	issuer := op.Claims().Issuer
 	if issuer == oc.Subject {
-		return !oc.StrictSigningKeyUsage
+		if !oc.StrictSigningKeyUsage {
+			return true
+		}
+		return op.Claims().Subject == oc.Subject
 	}
 	return oc.SigningKeys.Contains(issuer)
 }

--- a/v2/operator_claims_test.go
+++ b/v2/operator_claims_test.go
@@ -195,6 +195,12 @@ func TestSignedBy(t *testing.T) {
 	AssertEquals(uc2.DidSign(ac), true, t) // actual key
 	uc.SigningKeys.Add(publicKey(ckp2, t))
 	AssertEquals(uc.DidSign(ac), true, t) // signing key
+	uc.StrictSigningKeyUsage = true
+	AssertEquals(uc.DidSign(uc), true, t)
+	AssertEquals(uc.DidSign(ac), true, t)
+	uc2.StrictSigningKeyUsage = true
+	AssertEquals(uc2.DidSign(uc2), true, t)
+	AssertEquals(uc2.DidSign(ac), false, t)
 }
 
 func testAccountWithAccountServerURL(t *testing.T, u string) error {


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>