### PR TITLE
Separate test deps from v2 module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ before_script:
   - staticcheck ./...
 script:
   - mkdir cov
-  - go test -v -race -covermode=atomic -coverprofile=./cov/coverage.out -coverpkg=github.com/nats-io/jwt .
+  - if [ "$V" == "v2" ]; then GO_MOD_FILE="go_test.mod"; else GO_MOD_FILE="go.mod"; fi
+  - go test -modfile=$GO_MOD_FILE -v -race -covermode=atomic -coverprofile=./cov/coverage.out -coverpkg=github.com/nats-io/jwt .
   - gocovmerge ./cov/*.out > coverage.out
 
 deploy:

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,10 +1,5 @@
 module github.com/nats-io/jwt/v2
 
-require (
-	github.com/nats-io/jwt v1.2.2
-	github.com/nats-io/nkeys v0.3.0
-)
+go 1.16
 
-replace github.com/nats-io/jwt v1.2.2 => ../
-
-go 1.14
+require github.com/nats-io/nkeys v0.3.0

--- a/v2/go_test.mod
+++ b/v2/go_test.mod
@@ -1,0 +1,10 @@
+module github.com/nats-io/jwt/v2
+
+go 1.16
+
+require (
+	github.com/nats-io/jwt v1.2.2
+	github.com/nats-io/nkeys v0.3.0
+)
+
+replace github.com/nats-io/jwt v1.2.2 => ../

--- a/v2/go_test.sum
+++ b/v2/go_test.sum
@@ -1,0 +1,9 @@
+github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
+github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
+golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b h1:wSOdpTq0/eI46Ez/LkDwIsAKA71YP2SRKBODiRWM0as=
+golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/v2/test/decoder_migration_test.go
+++ b/v2/test/decoder_migration_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/nats-io/jwt/v2"
 	v1jwt "github.com/nats-io/jwt"
 	"github.com/nats-io/nkeys"
 )

--- a/v2/test/decoder_migration_test.go
+++ b/v2/test/decoder_migration_test.go
@@ -374,6 +374,7 @@ func equalExports(t *testing.T, o *v1jwt.Export, n *Export) {
 func equalImports(t *testing.T, o *v1jwt.Import, n *Import) {
 	AssertEquals(o.Name, n.Name, t)
 	AssertEquals(string(o.Subject), string(n.Subject), t)
+	//lint:ignore SA1019 testing
 	AssertEquals(string(o.To), string(n.To), t)
 	AssertEquals(int(o.Type), int(n.Type), t)
 

--- a/v2/test/genericclaims_test.go
+++ b/v2/test/genericclaims_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/nats-io/jwt/v2"
 	jwtv1 "github.com/nats-io/jwt"
 )
 

--- a/v2/test/util_test.go
+++ b/v2/test/util_test.go
@@ -81,34 +81,10 @@ func createAccountNKey(t *testing.T) nkeys.KeyPair {
 	return kp
 }
 
-func createUserNKey(t *testing.T) nkeys.KeyPair {
-	kp, err := nkeys.CreateUser()
-	if err != nil {
-		t.Fatal("error creating account kp", err)
-	}
-	return kp
-}
-
 func createOperatorNKey(t *testing.T) nkeys.KeyPair {
 	kp, err := nkeys.CreateOperator()
 	if err != nil {
 		t.Fatal("error creating operator kp", err)
-	}
-	return kp
-}
-
-func createServerNKey(t *testing.T) nkeys.KeyPair {
-	kp, err := nkeys.CreateServer()
-	if err != nil {
-		t.Fatal("error creating server kp", err)
-	}
-	return kp
-}
-
-func createClusterNKey(t *testing.T) nkeys.KeyPair {
-	kp, err := nkeys.CreateCluster()
-	if err != nil {
-		t.Fatal("error creating cluster kp", err)
 	}
 	return kp
 }
@@ -119,14 +95,6 @@ func publicKey(kp nkeys.KeyPair, t *testing.T) string {
 		t.Fatal("error reading public key", err)
 	}
 	return pk
-}
-
-func seedKey(kp nkeys.KeyPair, t *testing.T) []byte {
-	sk, err := kp.Seed()
-	if err != nil {
-		t.Fatal("error reading seed", err)
-	}
-	return sk
 }
 
 func encode(c Claims, kp nkeys.KeyPair, t *testing.T) string {

--- a/v2/test/util_test.go
+++ b/v2/test/util_test.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018-2021 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	. "github.com/nats-io/jwt/v2"
+	"github.com/nats-io/nkeys"
+)
+
+func Trace(message string) string {
+	lines := make([]string, 0, 32)
+	err := errors.New(message)
+	msg := err.Error()
+	lines = append(lines, msg)
+
+	for i := 2; true; i++ {
+		_, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+		msg := fmt.Sprintf("%s:%d", file, line)
+		lines = append(lines, msg)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func AssertEquals(expected, v interface{}, t *testing.T) {
+	if expected != v {
+		t.Fatalf("%v", Trace(fmt.Sprintf("The expected value %v != %v", expected, v)))
+	}
+}
+
+func AssertNil(v interface{}, t *testing.T) {
+	if v != nil {
+		t.FailNow()
+	}
+}
+
+func AssertNoError(err error, t *testing.T) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func AssertTrue(condition bool, t *testing.T) {
+	if !condition {
+		t.FailNow()
+	}
+}
+
+func AssertFalse(condition bool, t *testing.T) {
+	if condition {
+		t.FailNow()
+	}
+}
+
+func createAccountNKey(t *testing.T) nkeys.KeyPair {
+	kp, err := nkeys.CreateAccount()
+	if err != nil {
+		t.Fatal("error creating account kp", err)
+	}
+	return kp
+}
+
+func createUserNKey(t *testing.T) nkeys.KeyPair {
+	kp, err := nkeys.CreateUser()
+	if err != nil {
+		t.Fatal("error creating account kp", err)
+	}
+	return kp
+}
+
+func createOperatorNKey(t *testing.T) nkeys.KeyPair {
+	kp, err := nkeys.CreateOperator()
+	if err != nil {
+		t.Fatal("error creating operator kp", err)
+	}
+	return kp
+}
+
+func createServerNKey(t *testing.T) nkeys.KeyPair {
+	kp, err := nkeys.CreateServer()
+	if err != nil {
+		t.Fatal("error creating server kp", err)
+	}
+	return kp
+}
+
+func createClusterNKey(t *testing.T) nkeys.KeyPair {
+	kp, err := nkeys.CreateCluster()
+	if err != nil {
+		t.Fatal("error creating cluster kp", err)
+	}
+	return kp
+}
+
+func publicKey(kp nkeys.KeyPair, t *testing.T) string {
+	pk, err := kp.PublicKey()
+	if err != nil {
+		t.Fatal("error reading public key", err)
+	}
+	return pk
+}
+
+func seedKey(kp nkeys.KeyPair, t *testing.T) []byte {
+	sk, err := kp.Seed()
+	if err != nil {
+		t.Fatal("error reading seed", err)
+	}
+	return sk
+}
+
+func encode(c Claims, kp nkeys.KeyPair, t *testing.T) string {
+	s, err := c.Encode(kp)
+	if err != nil {
+		t.Fatal("error encoding claim", err)
+	}
+	return s
+}


### PR DESCRIPTION
Currently v2 go.mod depends on the v1 version (which includes a CVE), this transitive dependency makes vulnerability check tools report v2 as including the CVE, even though v1 is only being used for testing purposes.  This separates the test dependencies in the go.mod files so that this does not happen.

```sh
# Test without external dependencies
go test github.com/nats-io/jwt/v2 -v

# Tests with external dependencies (v1 dep in this case)
go test -modfile=go_test.mod github.com/nats-io/jwt/v2/test -v
```

Fixes #156
