### PR TITLE
[ADDED] New websocket connection types

### DIFF
--- a/v2/user_claims.go
+++ b/v2/user_claims.go
@@ -23,10 +23,12 @@ import (
 )
 
 const (
-	ConnectionTypeStandard  = "STANDARD"
-	ConnectionTypeWebsocket = "WEBSOCKET"
-	ConnectionTypeLeafnode  = "LEAFNODE"
-	ConnectionTypeMqtt      = "MQTT"
+	ConnectionTypeStandard   = "STANDARD"
+	ConnectionTypeWebsocket  = "WEBSOCKET"
+	ConnectionTypeLeafnode   = "LEAFNODE"
+	ConnectionTypeLeafnodeWS = "LEAFNODE_WS"
+	ConnectionTypeMqtt       = "MQTT"
+	ConnectionTypeMqttWS     = "MQTT_WS"
 )
 
 type UserPermissionLimits struct {

--- a/v2/user_claims_test.go
+++ b/v2/user_claims_test.go
@@ -358,6 +358,10 @@ func TestUserAllowedConnectionTypes(t *testing.T) {
 	uc := NewUserClaims(publicKey(ukp, t))
 	uc.AllowedConnectionTypes.Add(ConnectionTypeStandard)
 	uc.AllowedConnectionTypes.Add(ConnectionTypeWebsocket)
+	uc.AllowedConnectionTypes.Add(ConnectionTypeLeafnode)
+	uc.AllowedConnectionTypes.Add(ConnectionTypeLeafnodeWS)
+	uc.AllowedConnectionTypes.Add(ConnectionTypeMqtt)
+	uc.AllowedConnectionTypes.Add(ConnectionTypeMqttWS)
 	uJwt := encode(uc, akp, t)
 
 	uc2, err := DecodeUserClaims(uJwt)
@@ -366,6 +370,10 @@ func TestUserAllowedConnectionTypes(t *testing.T) {
 	}
 	AssertTrue(uc2.AllowedConnectionTypes.Contains(ConnectionTypeStandard), t)
 	AssertTrue(uc2.AllowedConnectionTypes.Contains(ConnectionTypeWebsocket), t)
+	AssertTrue(uc2.AllowedConnectionTypes.Contains(ConnectionTypeLeafnode), t)
+	AssertTrue(uc2.AllowedConnectionTypes.Contains(ConnectionTypeLeafnodeWS), t)
+	AssertTrue(uc2.AllowedConnectionTypes.Contains(ConnectionTypeMqtt), t)
+	AssertTrue(uc2.AllowedConnectionTypes.Contains(ConnectionTypeMqttWS), t)
 }
 
 func TestUserClaimRevocation(t *testing.T) {


### PR DESCRIPTION
Added a LEAF and MQTT websocket connection types. MQTT + WS is
not yet supported, but adding it in preparation.

The current WEBSOCKET connection type is really for regular clients.
Should probably have been something like CLIENT and CLIENT_WS instead
of STANDARD and WEBSOCKET, but at the time there was no plan/thinking
of adding websocket support to other type of connections.

The need for those 2 new connection types is because the admin may
want to have a "user" in the config that can connect as a leafnode,
either websocket or not, but not use this "user" to connect as
a regular client application. It will make more sense with MQTT:
one may want an user to connect for MQTT application, either WS or
not, but not for a non mqtt client. The new config would look like
this:

["MQTT", "MQTT_WS"]

Whereas previously, it would have to be:

["MQTT", "WEBSOCKET"]

But then this would allow a non MQTT client to connect as long as
the application connects to the websocket port (if opened).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>