### PR TITLE
[ADDED] Xkeys support

### DIFF
--- a/v2/account_claims.go
+++ b/v2/account_claims.go
@@ -171,9 +171,13 @@ func (a *Account) AddMapping(sub Subject, to ...WeightedMapping) {
 // AuthUsers are those users specified to bypass the authorization callout and should be used for the authorization service itself.
 // AllowedAccounts specifies which accounts, if any, that the authorization service can bind an authorized user to.
 // The authorization response, a user JWT, will still need to be signed by the correct account.
+// If optional XKey is specified, that is the public xkey (x25519) and the server will encrypt the request such that only the
+// holder of the private key can decrypt. The auth service can also optionally encrypt the response back to the server using it's
+// publick xkey which will be in the authorization request.
 type ExternalAuthorization struct {
 	AuthUsers       StringList `json:"auth_users"`
 	AllowedAccounts StringList `json:"allowed_accounts,omitempty"`
+	XKey            string     `json:"xkey,omitempty"`
 }
 
 func (ac *ExternalAuthorization) IsEnabled() bool {
@@ -205,6 +209,9 @@ func (ac *ExternalAuthorization) Validate(vr *ValidationResults) {
 		if !nkeys.IsValidPublicAccountKey(a) {
 			vr.AddError("Account %q is not a valid account public key", a)
 		}
+	}
+	if ac.XKey != "" && !nkeys.IsValidPublicCurveKey(ac.XKey) {
+		vr.AddError("XKey %q is not a valid public xkey", ac.XKey)
 	}
 }
 

--- a/v2/authorization_claims.go
+++ b/v2/authorization_claims.go
@@ -26,6 +26,7 @@ type ServerID struct {
 	Name string `json:"name"`
 	Host string `json:"host"`
 	ID   string `json:"id"`
+	XKey string `json:"xkey,omitempty"`
 }
 
 // ClientInformation is information about a client that is trying to authorize.

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -2,8 +2,9 @@ module github.com/nats-io/jwt/v2
 
 go 1.18
 
-require (
-	github.com/nats-io/nkeys v0.3.0
-)
+require github.com/nats-io/nkeys v0.3.1-0.20221205184623-5d8a6730c42c
 
-require golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b // indirect
+require (
+	golang.org/x/crypto v0.3.0 // indirect
+	golang.org/x/sys v0.2.0 // indirect
+)

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,9 +1,6 @@
-github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
-github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
-golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b h1:wSOdpTq0/eI46Ez/LkDwIsAKA71YP2SRKBODiRWM0as=
-golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+github.com/nats-io/nkeys v0.3.1-0.20221205184623-5d8a6730c42c h1:3/I6jrE5AT258Nl8IZCu/9oGIfIsV/GL8aKQR8+Lpq4=
+github.com/nats-io/nkeys v0.3.1-0.20221205184623-5d8a6730c42c/go.mod h1:JOEZlxMfMnmaLwr+mpmP+RGIYSxLNBFsZykCGaI2PvA=
+golang.org/x/crypto v0.3.0 h1:a06MkbcxBrEFc0w0QIZWXrH/9cCX6KJyWbBOIwAn+7A=
+golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/v2/go_test.mod
+++ b/v2/go_test.mod
@@ -4,9 +4,12 @@ go 1.18
 
 require (
 	github.com/nats-io/jwt v1.2.2
-	github.com/nats-io/nkeys v0.3.0
+	github.com/nats-io/nkeys v0.3.1-0.20221205184623-5d8a6730c42c
 )
 
-require golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b // indirect
+require (
+	golang.org/x/crypto v0.3.0 // indirect
+	golang.org/x/sys v0.2.0 // indirect
+)
 
 replace github.com/nats-io/jwt v1.2.2 => ../

--- a/v2/go_test.sum
+++ b/v2/go_test.sum
@@ -1,9 +1,6 @@
-github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
-github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
-golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b h1:wSOdpTq0/eI46Ez/LkDwIsAKA71YP2SRKBODiRWM0as=
-golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+github.com/nats-io/nkeys v0.3.1-0.20221205184623-5d8a6730c42c h1:3/I6jrE5AT258Nl8IZCu/9oGIfIsV/GL8aKQR8+Lpq4=
+github.com/nats-io/nkeys v0.3.1-0.20221205184623-5d8a6730c42c/go.mod h1:JOEZlxMfMnmaLwr+mpmP+RGIYSxLNBFsZykCGaI2PvA=
+golang.org/x/crypto v0.3.0 h1:a06MkbcxBrEFc0w0QIZWXrH/9cCX6KJyWbBOIwAn+7A=
+golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
The ServerID will now optionally include the public XKey from the server.
AccountClaims can specify a public XKey for ExternalAuthorization that will force the server's authorization requests to be encrypted.

Note go.mod changes temporary to pull in staged xkeys PR. Once merged will update.

Did update travis to test go 1.19 and that caused a bunch of fixups.

Signed-off-by: Derek Collison <derek@nats.io>