### PR TITLE
Authorization Response and Server ID additions

### DIFF
--- a/v2/claims.go
+++ b/v2/claims.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 The NATS Authors
+ * Copyright 2018-2022 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -40,7 +40,9 @@ const (
 	// ActivationClaim is the type of an activation JWT
 	ActivationClaim = "activation"
 	// AuthorizationRequestClaim is the type of an auth request claim JWT
-	AuthorizationRequestClaim = "authorization"
+	AuthorizationRequestClaim = "authorization_request"
+	// AuthorizationResponseClaim is the type of an auth response claim JWT
+	AuthorizationResponseClaim = "authorization_response"
 	// GenericClaim is a type that doesn't match Operator/Account/User/ActionClaim
 	GenericClaim = "generic"
 )
@@ -54,6 +56,8 @@ func IsGenericClaimType(s string) bool {
 	case UserClaim:
 		fallthrough
 	case AuthorizationRequestClaim:
+		fallthrough
+	case AuthorizationResponseClaim:
 		fallthrough
 	case ActivationClaim:
 		return false

--- a/v2/decoder.go
+++ b/v2/decoder.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The NATS Authors
+ * Copyright 2020-2022 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -145,7 +145,9 @@ func loadClaims(data []byte) (int, Claims, error) {
 	case ActivationClaim:
 		claim, err = loadActivation(data, id.Version())
 	case AuthorizationRequestClaim:
-		claim, err = loadAuthorization(data, id.Version())
+		claim, err = loadAuthorizationRequest(data, id.Version())
+	case AuthorizationResponseClaim:
+		claim, err = loadAuthorizationResponse(data, id.Version())
 	case "cluster":
 		return -1, nil, errors.New("ClusterClaims are not supported")
 	case "server":

--- a/v2/decoder_authorization.go
+++ b/v2/decoder_authorization.go
@@ -19,10 +19,18 @@ import (
 	"encoding/json"
 )
 
-func loadAuthorization(data []byte, version int) (*AuthorizationRequestClaims, error) {
+func loadAuthorizationRequest(data []byte, version int) (*AuthorizationRequestClaims, error) {
 	var ac AuthorizationRequestClaims
 	if err := json.Unmarshal(data, &ac); err != nil {
 		return nil, err
 	}
 	return &ac, nil
+}
+
+func loadAuthorizationResponse(data []byte, version int) (*AuthorizationResponseClaims, error) {
+	var arc AuthorizationResponseClaims
+	if err := json.Unmarshal(data, &arc); err != nil {
+		return nil, err
+	}
+	return &arc, nil
 }


### PR DESCRIPTION
Added in authorization response for propagating errors back to a NATS server.

Also added in version, cluster and tags to the server info for an authorization request.

Signed-off-by: Derek Collison <derek@nats.io>