### PR TITLE
Sort Signing Keys on Marshal

### DIFF
--- a/v2/signingkeys.go
+++ b/v2/signingkeys.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/nats-io/nkeys"
 )
@@ -124,10 +125,14 @@ func (sk *SigningKeys) MarshalJSON() ([]byte, error) {
 	if sk == nil {
 		return nil, nil
 	}
+
+	keys := sk.Keys()
+	sort.Strings(keys)
+
 	var a []interface{}
-	for k, v := range *sk {
-		if v != nil {
-			a = append(a, v)
+	for _, k := range keys {
+		if (*sk)[k] != nil {
+			a = append(a, (*sk)[k])
 		} else {
 			a = append(a, k)
 		}


### PR DESCRIPTION
Sort the signing keys by their public nkey during the json marshaling process to ensure the generated json array is always the same.

Since ranging over a map in golang is intentionally random, prior behavior would generate a random order for the signing key output. Arrays in json are considered ordered, so this would cause test that compare the json generated from the same `SigningKeys` to occasionally fail: `["sk1","sk2"] != ["sk2","sk1"]`