### PR TITLE
[FEAT] Add server_name field in ClientTLS auth request claims

### DIFF
--- a/v2/authorization_claims.go
+++ b/v2/authorization_claims.go
@@ -70,6 +70,7 @@ type ClientTLS struct {
 	Cipher         string       `json:"cipher,omitempty"`
 	Certs          StringList   `json:"certs,omitempty"`
 	VerifiedChains []StringList `json:"verified_chains,omitempty"`
+	ServerName     string       `json:"server_name,omitempty"`
 }
 
 // AuthorizationRequest represents all the information we know about the client that


### PR DESCRIPTION
This PR introduces a new field on ClientTLS struct to hold the server name used in TLS handshake.