### PR TITLE
[CHANGE] import `share` is now possible for stream and service exports

### DIFF
--- a/v2/imports.go
+++ b/v2/imports.go
@@ -83,9 +83,6 @@ func (i *Import) Validate(actPubKey string, vr *ValidationResults) {
 		}
 	}
 
-	if i.Share && !i.IsService() {
-		vr.AddError("sharing information (for latency tracking) is only valid for services: %q", i.Subject)
-	}
 	var act *ActivationClaims
 
 	if i.Token != "" {

--- a/v2/imports_test.go
+++ b/v2/imports_test.go
@@ -291,30 +291,6 @@ func TestStreamImportWithWildcardPrefix(t *testing.T) {
 	}
 }
 
-func TestStreamImportInformationSharing(t *testing.T) {
-	ak := createAccountNKey(t)
-	akp := publicKey(ak, t)
-	// broken import share won't work with streams
-	i := &Import{Subject: "foo", Account: akp, Type: Stream, Share: true}
-	vr := CreateValidationResults()
-	i.Validate("", vr)
-
-	if len(vr.Issues) != 1 {
-		t.Errorf("should have registered 1 issues with this import, got %d", len(vr.Issues))
-	}
-	if !vr.IsBlocking(true) {
-		t.Fatalf("issue is expected to be blocking")
-	}
-	// import share will work with service
-	i.Type = Service
-	vr = CreateValidationResults()
-	i.Validate("", vr)
-
-	if len(vr.Issues) != 0 {
-		t.Errorf("should have registered 0 issues with this import, got %d", len(vr.Issues))
-	}
-}
-
 func TestImportsValidation(t *testing.T) {
 	ak := createAccountNKey(t)
 	akp := publicKey(ak, t)


### PR DESCRIPTION
 `share` previously constrained to services. But with the new tracing functionality this is no longer true, as I understand it anything can be traced.