### PR TITLE
add omitempty to authorization.auth_users

### DIFF
--- a/v2/account_claims.go
+++ b/v2/account_claims.go
@@ -175,7 +175,7 @@ func (a *Account) AddMapping(sub Subject, to ...WeightedMapping) {
 // holder of the private key can decrypt. The auth service can also optionally encrypt the response back to the server using it's
 // publick xkey which will be in the authorization request.
 type ExternalAuthorization struct {
-	AuthUsers       StringList `json:"auth_users"`
+	AuthUsers       StringList `json:"auth_users,omitempty"`
 	AllowedAccounts StringList `json:"allowed_accounts,omitempty"`
 	XKey            string     `json:"xkey,omitempty"`
 }


### PR DESCRIPTION
In account claims, `authorization` is a struct so it always gets serialized even though it has `omitempty`

And since `authorization.auth_users` doesn't currently have `omitempty`, by default that always gets serialized to `null`

So every account JWT by default is ending up with:

```
  "nats": {
    "authorization": {
      "auth_users": null
    },
    ...
}
```

After this change, it will be:

```
  "nats": {
    "authorization": {},
    ...
}
```

To get rid of the empty `authorization` field, we would have to change `Account.Authorization` to a Pointer