### PR TITLE
[ADDED] Connection type "in process"

### DIFF
--- a/v2/user_claims.go
+++ b/v2/user_claims.go
@@ -29,6 +29,7 @@ const (
 	ConnectionTypeLeafnodeWS = "LEAFNODE_WS"
 	ConnectionTypeMqtt       = "MQTT"
 	ConnectionTypeMqttWS     = "MQTT_WS"
+	ConnectionTypeInProcess  = "IN_PROCESS"
 )
 
 type UserPermissionLimits struct {

--- a/v2/user_claims_test.go
+++ b/v2/user_claims_test.go
@@ -361,6 +361,7 @@ func TestUserAllowedConnectionTypes(t *testing.T) {
 	uc.AllowedConnectionTypes.Add(ConnectionTypeLeafnodeWS)
 	uc.AllowedConnectionTypes.Add(ConnectionTypeMqtt)
 	uc.AllowedConnectionTypes.Add(ConnectionTypeMqttWS)
+	uc.AllowedConnectionTypes.Add(ConnectionTypeInProcess)
 	uJwt := encode(uc, akp, t)
 
 	uc2, err := DecodeUserClaims(uJwt)
@@ -373,6 +374,7 @@ func TestUserAllowedConnectionTypes(t *testing.T) {
 	AssertTrue(uc2.AllowedConnectionTypes.Contains(ConnectionTypeLeafnodeWS), t)
 	AssertTrue(uc2.AllowedConnectionTypes.Contains(ConnectionTypeMqtt), t)
 	AssertTrue(uc2.AllowedConnectionTypes.Contains(ConnectionTypeMqttWS), t)
+	AssertTrue(uc2.AllowedConnectionTypes.Contains(ConnectionTypeInProcess), t)
 }
 
 func TestUserClaimRevocation(t *testing.T) {


### PR DESCRIPTION
Added `ConnectionTypeInProcess` to the `UserPermissionLimits.AllowedConnectionTypes` list of possible types.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>