### PR TITLE
Add `ClusterTraffic` to account claims

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -7,10 +7,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - go: '1.19.x'
+          - go: "stable"
             os: ubuntu-latest
             canonical: true
-          - go: '1.19.x'
+          - go: "stable"
             os: windows-latest
             canonical: false
 
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{matrix.go}}
-
 
       - name: Install deps
         shell: bash --noprofile --norc -x -eo pipefail {0}

--- a/v2/account_claims.go
+++ b/v2/account_claims.go
@@ -241,6 +241,7 @@ type Account struct {
 	Mappings           Mapping               `json:"mappings,omitempty"`
 	Authorization      ExternalAuthorization `json:"authorization,omitempty"`
 	Trace              *MsgTrace             `json:"trace,omitempty"`
+	ClusterTraffic     string                `json:"cluster_traffic,omitempty"`
 	Info
 	GenericFields
 }

--- a/v2/types.go
+++ b/v2/types.go
@@ -309,7 +309,7 @@ func (l *Limits) Validate(vr *ValidationResults) {
 		}
 	}
 
-	if l.Times != nil && len(l.Times) > 0 {
+	if len(l.Times) > 0 {
 		for _, t := range l.Times {
 			t.Validate(vr)
 		}

--- a/v2/v1compat/types.go
+++ b/v2/v1compat/types.go
@@ -197,7 +197,7 @@ func (l *Limits) Validate(vr *ValidationResults) {
 		}
 	}
 
-	if l.Times != nil && len(l.Times) > 0 {
+	if len(l.Times) > 0 {
 		for _, t := range l.Times {
 			t.Validate(vr)
 		}


### PR DESCRIPTION
For supporting nats-io/nats-server#5466.

For now expected values would be:
* `"system"` - use the system account (default, as today)
* `"owner"` - use the same account that owns the asset
* `"account:ACCNAME"` - use a third specified `ACCNAME`

Signed-off-by: Neil Twigg <neil@nats.io>