### PR TITLE
[CHANGE] retracts case-sensitive support for tags

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -4,6 +4,11 @@ go 1.18
 
 require github.com/nats-io/nkeys v0.4.7
 
+retract (
+	v2.7.1 // contains retractions only
+	v2.7.0 // includes case insensitive changes to tags that break jetstream placement
+)
+
 require (
 	golang.org/x/crypto v0.19.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect

--- a/v2/operator_claims_test.go
+++ b/v2/operator_claims_test.go
@@ -459,6 +459,7 @@ func TestTags(t *testing.T) {
 	}
 
 	AssertTrue(oc.GenericFields.Tags.Contains("one"), t)
+	AssertTrue(oc.GenericFields.Tags.Contains("ONE"), t)
 	AssertTrue(oc.GenericFields.Tags.Contains("TWO"), t)
 	AssertTrue(oc.GenericFields.Tags.Contains("three"), t)
 }


### PR DESCRIPTION
This PR changes the version of the JWT library, which has added a new "Exact" API that is case-sensitive. The use of the old API will store lowercase entries and match them in a case-insensitive manner. This enables current usage in nats-server to work as it has without changes.

2.11 will switch the APIs to use the case-sensitive ("Exact") variants of the API.

https://github.com/nats-io/nats-server/pull/5954
