### PR TITLE
[CHANGE] made cluster_traffic a string

### DIFF
--- a/v2/account_claims.go
+++ b/v2/account_claims.go
@@ -255,7 +255,7 @@ type Account struct {
 	Mappings           Mapping               `json:"mappings,omitempty"`
 	Authorization      ExternalAuthorization `json:"authorization,omitempty"`
 	Trace              *MsgTrace             `json:"trace,omitempty"`
-	ClusterTraffic     ClusterTraffic        `json:"cluster_traffic,omitempty"`
+	ClusterTraffic     string                `json:"cluster_traffic,omitempty"`
 	Info
 	GenericFields
 }
@@ -324,7 +324,8 @@ func (a *Account) Validate(acct *AccountClaims, vr *ValidationResults) {
 	a.SigningKeys.Validate(vr)
 	a.Info.Validate(vr)
 
-	if err := a.ClusterTraffic.Valid(); err != nil {
+	ct := ClusterTraffic(a.ClusterTraffic)
+	if err := ct.Valid(); err != nil {
 		vr.AddError(err.Error())
 	}
 }


### PR DESCRIPTION
this allows the server to do whatever it wants, while validations are casted to the `ClusterTraffic` string type.