### PR TITLE
Alternative TagList implementation that is case preserving, but case insensitive for matches

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -4,6 +4,11 @@ go 1.18
 
 require github.com/nats-io/nkeys v0.4.7
 
+retract (
+	v2.7.1 // contains retractions only
+	v2.7.0 // includes case insensitive changes to tags that break jetstream placement
+)
+
 require (
 	golang.org/x/crypto v0.19.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect

--- a/v2/operator_claims_test.go
+++ b/v2/operator_claims_test.go
@@ -459,6 +459,7 @@ func TestTags(t *testing.T) {
 	}
 
 	AssertTrue(oc.GenericFields.Tags.Contains("one"), t)
+	AssertTrue(oc.GenericFields.Tags.Contains("ONE"), t)
 	AssertTrue(oc.GenericFields.Tags.Contains("TWO"), t)
 	AssertTrue(oc.GenericFields.Tags.Contains("three"), t)
 }


### PR DESCRIPTION
[RETRACT] 2.7.0/2.7.1

[CHANGE] tag list is case-preserving but case-insensitive for matches 
[FEAT] added FilterTag() to filter a set of entries by the tag name (tag name is considered case-insensitive) 
[FEAT] added TagValueFor() to return all values matching a particular tag name (tag name is considered case-insensitive)