### PR TITLE
Allow external signing of JWTs

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -7,10 +7,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - go: "stable"
+          - go: stable
             os: ubuntu-latest
             canonical: true
-          - go: "stable"
+          - go: stable
             os: windows-latest
             canonical: false
 
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{matrix.go}}
 

--- a/v2/account_claims.go
+++ b/v2/account_claims.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 The NATS Authors
+ * Copyright 2018-2024 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -133,7 +133,7 @@ func (o *OperatorLimits) Validate(vr *ValidationResults) {
 	}
 }
 
-// Mapping for publishes
+// WeightedMapping for publishes
 type WeightedMapping struct {
 	Subject Subject `json:"subject"`
 	Weight  uint8   `json:"weight,omitempty"`
@@ -177,13 +177,13 @@ func (a *Account) AddMapping(sub Subject, to ...WeightedMapping) {
 	a.Mappings[sub] = to
 }
 
-// Enable external authorization for account users.
+// ExternalAuthorization enables external authorization for account users.
 // AuthUsers are those users specified to bypass the authorization callout and should be used for the authorization service itself.
 // AllowedAccounts specifies which accounts, if any, that the authorization service can bind an authorized user to.
 // The authorization response, a user JWT, will still need to be signed by the correct account.
 // If optional XKey is specified, that is the public xkey (x25519) and the server will encrypt the request such that only the
 // holder of the private key can decrypt. The auth service can also optionally encrypt the response back to the server using it's
-// publick xkey which will be in the authorization request.
+// public xkey which will be in the authorization request.
 type ExternalAuthorization struct {
 	AuthUsers       StringList `json:"auth_users,omitempty"`
 	AllowedAccounts StringList `json:"allowed_accounts,omitempty"`
@@ -194,12 +194,12 @@ func (ac *ExternalAuthorization) IsEnabled() bool {
 	return len(ac.AuthUsers) > 0
 }
 
-// Helper function to determine if external authorization is enabled.
+// HasExternalAuthorization helper function to determine if external authorization is enabled.
 func (a *Account) HasExternalAuthorization() bool {
 	return a.Authorization.IsEnabled()
 }
 
-// Helper function to setup external authorization.
+// EnableExternalAuthorization helper function to setup external authorization.
 func (a *Account) EnableExternalAuthorization(users ...string) {
 	a.Authorization.AuthUsers.Add(users...)
 }
@@ -357,13 +357,17 @@ func NewAccountClaims(subject string) *AccountClaims {
 
 // Encode converts account claims into a JWT string
 func (a *AccountClaims) Encode(pair nkeys.KeyPair) (string, error) {
+	return a.EncodeWithSigner(pair, nil)
+}
+
+func (a *AccountClaims) EncodeWithSigner(pair nkeys.KeyPair, fn SignFn) (string, error) {
 	if !nkeys.IsValidPublicAccountKey(a.Subject) {
 		return "", errors.New("expected subject to be account public key")
 	}
 	sort.Sort(a.Exports)
 	sort.Sort(a.Imports)
 	a.Type = AccountClaim
-	return a.ClaimsData.encode(pair, a)
+	return a.ClaimsData.encode(pair, a, fn)
 }
 
 // DecodeAccountClaims decodes account claims from a JWT string

--- a/v2/activation_claims.go
+++ b/v2/activation_claims.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The NATS Authors
+ * Copyright 2018-2024 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -72,11 +72,15 @@ func NewActivationClaims(subject string) *ActivationClaims {
 
 // Encode turns an activation claim into a JWT strimg
 func (a *ActivationClaims) Encode(pair nkeys.KeyPair) (string, error) {
+	return a.EncodeWithSigner(pair, nil)
+}
+
+func (a *ActivationClaims) EncodeWithSigner(pair nkeys.KeyPair, fn SignFn) (string, error) {
 	if !nkeys.IsValidPublicAccountKey(a.ClaimsData.Subject) {
 		return "", errors.New("expected subject to be an account")
 	}
 	a.Type = ActivationClaim
-	return a.ClaimsData.encode(pair, a)
+	return a.ClaimsData.encode(pair, a, fn)
 }
 
 // DecodeActivationClaims tries to create an activation claim from a JWT string

--- a/v2/authorization_claims.go
+++ b/v2/authorization_claims.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The NATS Authors
+ * Copyright 2022-2024 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -113,8 +113,12 @@ func (ac *AuthorizationRequestClaims) Validate(vr *ValidationResults) {
 
 // Encode tries to turn the auth request claims into a JWT string.
 func (ac *AuthorizationRequestClaims) Encode(pair nkeys.KeyPair) (string, error) {
+	return ac.EncodeWithSigner(pair, nil)
+}
+
+func (ac *AuthorizationRequestClaims) EncodeWithSigner(pair nkeys.KeyPair, fn SignFn) (string, error) {
 	ac.Type = AuthorizationRequestClaim
-	return ac.ClaimsData.encode(pair, ac)
+	return ac.ClaimsData.encode(pair, ac, fn)
 }
 
 // DecodeAuthorizationRequestClaims tries to parse an auth request claims from a JWT string
@@ -242,6 +246,10 @@ func (ar *AuthorizationResponseClaims) Validate(vr *ValidationResults) {
 
 // Encode tries to turn the auth request claims into a JWT string.
 func (ar *AuthorizationResponseClaims) Encode(pair nkeys.KeyPair) (string, error) {
+	return ar.EncodeWithSigner(pair, nil)
+}
+
+func (ar *AuthorizationResponseClaims) EncodeWithSigner(pair nkeys.KeyPair, fn SignFn) (string, error) {
 	ar.Type = AuthorizationResponseClaim
-	return ar.ClaimsData.encode(pair, ar)
+	return ar.ClaimsData.encode(pair, ar, fn)
 }

--- a/v2/exports.go
+++ b/v2/exports.go
@@ -273,7 +273,7 @@ func isContainedIn(kind ExportType, subjects []Subject, vr *ValidationResults) {
 }
 
 // Validate calls validate on all of the exports
-func (e *Exports) Validate(vr *ValidationResults) error {
+func (e *Exports) Validate(vr *ValidationResults) {
 	var serviceSubjects []Subject
 	var streamSubjects []Subject
 
@@ -292,8 +292,6 @@ func (e *Exports) Validate(vr *ValidationResults) error {
 
 	isContainedIn(Service, serviceSubjects, vr)
 	isContainedIn(Stream, streamSubjects, vr)
-
-	return nil
 }
 
 // HasExportContainingSubject checks if the export list has an export with the provided subject

--- a/v2/genericlaims.go
+++ b/v2/genericlaims.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2018-2024 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -107,7 +107,11 @@ func (gc *GenericClaims) Payload() interface{} {
 
 // Encode takes a generic claims and creates a JWT string
 func (gc *GenericClaims) Encode(pair nkeys.KeyPair) (string, error) {
-	return gc.ClaimsData.encode(pair, gc)
+	return gc.ClaimsData.encode(pair, gc, nil)
+}
+
+func (gc *GenericClaims) EncodeWithSigner(pair nkeys.KeyPair, fn SignFn) (string, error) {
+	return gc.ClaimsData.encode(pair, gc, fn)
 }
 
 // Validate checks the generic part of the claims data

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -2,7 +2,7 @@ module github.com/nats-io/jwt/v2
 
 go 1.22
 
-require github.com/nats-io/nkeys v0.4.7
+require github.com/nats-io/nkeys v0.4.8
 
 retract (
 	v2.7.1 // contains retractions only
@@ -10,6 +10,6 @@ retract (
 )
 
 require (
-	golang.org/x/crypto v0.19.0 // indirect
-	golang.org/x/sys v0.17.0 // indirect
+	golang.org/x/crypto v0.29.0 // indirect
+	golang.org/x/sys v0.27.0 // indirect
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,6 +1,6 @@
-github.com/nats-io/nkeys v0.4.7 h1:RwNJbbIdYCoClSDNY7QVKZlyb/wfT6ugvFCiKy6vDvI=
-github.com/nats-io/nkeys v0.4.7/go.mod h1:kqXRgRDPlGy7nGaEDMuYzmiJCIAAWDK0IMBtDmGD0nc=
-golang.org/x/crypto v0.19.0 h1:ENy+Az/9Y1vSrlrvBSyna3PITt4tiZLf7sgCjZBX7Wo=
-golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
-golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
-golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+github.com/nats-io/nkeys v0.4.8 h1:+wee30071y3vCZAYRsnrmIPaOe47A/SkK/UBDPdIV70=
+github.com/nats-io/nkeys v0.4.8/go.mod h1:kqXRgRDPlGy7nGaEDMuYzmiJCIAAWDK0IMBtDmGD0nc=
+golang.org/x/crypto v0.29.0 h1:L5SG1JTTXupVV3n6sUqMTeWbjAyfPwoda2DLX8J8FrQ=
+golang.org/x/crypto v0.29.0/go.mod h1:+F4F4N5hv6v38hfeYwTdx20oUvLLc+QfrE9Ax9HtgRg=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/v2/operator_claims.go
+++ b/v2/operator_claims.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The NATS Authors
+ * Copyright 2018-2024 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -191,6 +191,10 @@ func (oc *OperatorClaims) DidSign(op Claims) bool {
 
 // Encode the claims into a JWT string
 func (oc *OperatorClaims) Encode(pair nkeys.KeyPair) (string, error) {
+	return oc.EncodeWithSigner(pair, nil)
+}
+
+func (oc *OperatorClaims) EncodeWithSigner(pair nkeys.KeyPair, fn SignFn) (string, error) {
 	if !nkeys.IsValidPublicOperatorKey(oc.Subject) {
 		return "", errors.New("expected subject to be an operator public key")
 	}
@@ -199,7 +203,7 @@ func (oc *OperatorClaims) Encode(pair nkeys.KeyPair) (string, error) {
 		return "", err
 	}
 	oc.Type = OperatorClaim
-	return oc.ClaimsData.encode(pair, oc)
+	return oc.ClaimsData.encode(pair, oc, fn)
 }
 
 func (oc *OperatorClaims) ClaimType() ClaimType {

--- a/v2/user_claims.go
+++ b/v2/user_claims.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 The NATS Authors
+ * Copyright 2018-2024 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -92,11 +92,15 @@ func (u *UserClaims) HasEmptyPermissions() bool {
 
 // Encode tries to turn the user claims into a JWT string
 func (u *UserClaims) Encode(pair nkeys.KeyPair) (string, error) {
+	return u.EncodeWithSigner(pair, nil)
+}
+
+func (u *UserClaims) EncodeWithSigner(pair nkeys.KeyPair, fn SignFn) (string, error) {
 	if !nkeys.IsValidPublicUserKey(u.Subject) {
 		return "", errors.New("expected subject to be user public key")
 	}
 	u.Type = UserClaim
-	return u.ClaimsData.encode(pair, u)
+	return u.ClaimsData.encode(pair, u, fn)
 }
 
 // DecodeUserClaims tries to parse a user claims from a JWT string


### PR DESCRIPTION
feat: Claims interface now has `EncodeWithSigner(nkeys.KeyPair`, fn: SignFn)`  where signing can be delegated to a function. The `type SignFn func(pub string, data []byte) ([]byte, error)` is provided with the public key whose matching private key should be used to sign the provided payload.

This feature enables an external signing service to be incorporated in the workflow for signing a JWT.