### PR TITLE
[ADDED] `ProxyRequired` user claims property

### DIFF
--- a/v2/user_claims.go
+++ b/v2/user_claims.go
@@ -36,6 +36,7 @@ type UserPermissionLimits struct {
 	Permissions
 	Limits
 	BearerToken            bool       `json:"bearer_token,omitempty"`
+	ProxyRequired          bool       `json:"proxy_required,omitempty"`
 	AllowedConnectionTypes StringList `json:"allowed_connection_types,omitempty"`
 }
 


### PR DESCRIPTION
This would be used in the server to enforce that a user connects through a trusted proxy.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>