### PR TITLE
fix: added a check for the size of JWT token

### DIFF
--- a/v2/decoder.go
+++ b/v2/decoder.go
@@ -29,6 +29,9 @@ const libVersion = 2
 // MaxTokenSize is the maximum size of a JWT token in bytes
 const MaxTokenSize = 1024 * 1024 // 1MB
 
+// ErrTokenTooLarge is returned when a token exceeds MaxTokenSize
+var ErrTokenTooLarge = errors.New("token too large")
+
 type identifier struct {
 	Type          ClaimType `json:"type,omitempty"`
 	GenericFields `json:"nats,omitempty"`
@@ -60,7 +63,7 @@ type v1ClaimsDataDeletedFields struct {
 // not valid or verification fails an error is returned.
 func Decode(token string) (Claims, error) {
 	if len(token) > MaxTokenSize {
-		return nil, fmt.Errorf("token size %d exceeds maximum of %d bytes", len(token), MaxTokenSize)
+		return nil, fmt.Errorf("token size %d exceeds maximum of %d bytes: %w", len(token), MaxTokenSize, ErrTokenTooLarge)
 	}
 	// must have 3 chunks
 	chunks := strings.Split(token, ".")

--- a/v2/decoder.go
+++ b/v2/decoder.go
@@ -26,6 +26,9 @@ import (
 
 const libVersion = 2
 
+// MaxTokenSize is the maximum size of a JWT token in bytes
+const MaxTokenSize = 1024 * 1024 // 1MB
+
 type identifier struct {
 	Type          ClaimType `json:"type,omitempty"`
 	GenericFields `json:"nats,omitempty"`
@@ -56,6 +59,9 @@ type v1ClaimsDataDeletedFields struct {
 // doesn't match the expected algorithm, or the claim is
 // not valid or verification fails an error is returned.
 func Decode(token string) (Claims, error) {
+	if len(token) > MaxTokenSize {
+		return nil, fmt.Errorf("token size %d exceeds maximum of %d bytes", len(token), MaxTokenSize)
+	}
 	// must have 3 chunks
 	chunks := strings.Split(token, ".")
 	if len(chunks) != 3 {

--- a/v2/decoder_test.go
+++ b/v2/decoder_test.go
@@ -401,3 +401,14 @@ func TestUsingURLDecoder(t *testing.T) {
 		t.Fatal("should have returned activation")
 	}
 }
+
+func TestDecodeTokenSizeLimit(t *testing.T) {
+	token := strings.Repeat("a", MaxTokenSize+1)
+	_, err := Decode(token)
+	if err == nil {
+		t.Fatal("expected error for oversized token")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/v2/decoder_test.go
+++ b/v2/decoder_test.go
@@ -17,6 +17,7 @@ package jwt
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -403,12 +404,20 @@ func TestUsingURLDecoder(t *testing.T) {
 }
 
 func TestDecodeTokenSizeLimit(t *testing.T) {
+	// over limit should fail with ErrTokenTooLarge
 	token := strings.Repeat("a", MaxTokenSize+1)
 	_, err := Decode(token)
 	if err == nil {
 		t.Fatal("expected error for oversized token")
 	}
-	if !strings.Contains(err.Error(), "exceeds maximum") {
-		t.Fatalf("unexpected error: %v", err)
+	if !errors.Is(err, ErrTokenTooLarge) {
+		t.Fatalf("expected ErrTokenTooLarge, got: %v", err)
+	}
+
+	// exactly at limit should not be rejected for size
+	token = strings.Repeat("a", MaxTokenSize)
+	_, err = Decode(token)
+	if err != nil && errors.Is(err, ErrTokenTooLarge) {
+		t.Fatal("token at exactly MaxTokenSize should not be rejected for size")
 	}
 }


### PR DESCRIPTION
Note that now all JWTs are limited to 1MB - which may or not be breaking. Note that Generic JWTs could possibly have whatever size they want but this change affects all decoding.