### PR TITLE
docs: how to enable/disable JetStream when creating AccountClaims

### DIFF
--- a/v2/account_claims.go
+++ b/v2/account_claims.go
@@ -347,9 +347,11 @@ func NewAccountClaims(subject string) *AccountClaims {
 	c.SigningKeys = make(SigningKeys)
 	// Set to unlimited to start. We do it this way so we get compiler
 	// errors if we add to the OperatorLimits.
+	// JetStream is disabled by default by setting MemoryStorage and DiskStorage to zero, instead of NoLimit.
 	c.Limits = OperatorLimits{
 		NatsLimits{NoLimit, NoLimit, NoLimit},
 		AccountLimits{NoLimit, NoLimit, true, false, NoLimit, NoLimit},
+		// Default zeros implies that JetStream is not enabled by default, see OperatorLimits.IsJSEnabled().
 		JetStreamLimits{0, 0, 0, 0, 0, 0, 0, false},
 		JetStreamTieredLimits{},
 	}

--- a/v2/account_claims_test.go
+++ b/v2/account_claims_test.go
@@ -1109,3 +1109,57 @@ func TestSignFn(t *testing.T) {
 		t.Fatalf("claims validation should not have failed, got %+v", vr.Issues)
 	}
 }
+
+func TestNewAccountClaimsShouldNotEnableJetStream(t *testing.T) {
+	uut := NewAccountClaims("test")
+
+	if uut.Limits.IsJSEnabled() {
+		t.Fatal("breaking change detected, default AccountClaims enables JS")
+	}
+}
+
+func TestNewAccountClaimsShouldEnableJetStream(t *testing.T) {
+	type claimsModifier func(claims *AccountClaims)
+	type testCase struct {
+		description string
+		mod         claimsModifier
+	}
+
+	tests := []testCase{
+		{
+			description: "DiskStorage set to NoLimit",
+			mod: func(claims *AccountClaims) {
+				claims.Limits.MemoryStorage = NoLimit
+			},
+		},
+		{
+			description: "DiskStorage set to a limit",
+			mod: func(claims *AccountClaims) {
+				claims.Limits.MemoryStorage = 5368709120
+			},
+		},
+		{
+			description: "MemoryStorage set to NoLimit",
+			mod: func(claims *AccountClaims) {
+				claims.Limits.MemoryStorage = NoLimit
+			},
+		},
+		{
+			description: "MemoryStorage set to a limit",
+			mod: func(claims *AccountClaims) {
+				claims.Limits.MemoryStorage = 5368709120
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			uut := NewAccountClaims("test")
+			test.mod(uut)
+
+			if !uut.Limits.IsJSEnabled() {
+				t.Fatal("expected JetStream to be enabled")
+			}
+		})
+	}
+}


### PR DESCRIPTION
The nats-server will (only) enable JetStream on an account if `DiskStorage` and/or `MemoryStorage` is set to a non-zero value in the Account JWT Limits. This is due to legacy reasons and cannot be easily changed due to the global impact of already existing NATS clusters based on decentralized auth.

Issue: https://github.com/nats-io/jwt/issues/249
